### PR TITLE
refactor: preproc cache engine, config updates, adapters cleanup

### DIFF
--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -1,6 +1,7 @@
 pub mod custom;
 pub mod decompress;
 pub mod ffmpeg;
+pub mod ipynb;
 pub mod mbox;
 pub mod postproc;
 use std::sync::Arc;
@@ -120,6 +121,7 @@ pub fn get_all_adapters(custom_adapters: Option<Vec<CustomAdapterConfig>>) -> Ad
 
     let internal_adapters: Vec<Arc<dyn FileAdapter>> = vec![
         Arc::new(PostprocPageBreaks::default()),
+        Arc::new(ipynb::IpynbAdapter::new()),
         Arc::new(ffmpeg::FFmpegAdapter::new()),
         Arc::new(zip::ZipAdapter::new()),
         Arc::new(decompress::DecompressAdapter::new()),

--- a/src/adapters/custom.rs
+++ b/src/adapters/custom.rs
@@ -117,7 +117,7 @@ lazy_static! {
             name: "pandoc".to_string(),
             description: "Uses pandoc to convert binary/unreadable text documents to plain markdown-like text".to_string(),
             version: 3,
-            extensions: strs(&["epub", "odt", "docx", "fb2", "ipynb", "html", "htm"]),
+            extensions: strs(&["epub", "odt", "docx", "fb2", "html", "htm"]),
             binary: "pandoc".to_string(),
             mimetypes: None,
             // simpler markdown (with more information loss but plainer text)
@@ -146,6 +146,106 @@ lazy_static! {
             disabled_by_default: None,
             match_only_by_mime: None,
             output_path_hint: Some("${input_virtual_path}.txt.asciipagebreaks".into())
+        }
+        ,
+        CustomAdapterConfig {
+            name: "djvutxt".to_string(),
+            description: "Uses djvutxt to extract plain text from DjVu files".to_string(),
+            version: 1,
+            extensions: strs(&["djvu", "djv"]),
+            mimetypes: Some(strs(&["image/vnd.djvu", "image/x-djvu"])),
+            binary: "djvutxt".to_string(),
+            args: strs(&["$input_virtual_path"]),
+            disabled_by_default: None,
+            match_only_by_mime: None,
+            output_path_hint: Some("${input_virtual_path}.txt".into()),
+        }
+        ,
+        CustomAdapterConfig {
+            name: "hdf5".to_string(),
+            description: "Uses h5dump to print HDF5 headers and attributes".to_string(),
+            version: 1,
+            extensions: strs(&["h5", "hdf5", "hdf"]),
+            mimetypes: Some(strs(&["application/x-hdf5", "application/x-hdf"])),
+            binary: "h5dump".to_string(),
+            args: strs(&["-H", "$input_virtual_path"]),
+            disabled_by_default: None,
+            match_only_by_mime: None,
+            output_path_hint: Some("${input_virtual_path}.txt".into()),
+        }
+        ,
+        CustomAdapterConfig {
+            name: "netcdf".to_string(),
+            description: "Uses ncdump to print NetCDF dataset metadata".to_string(),
+            version: 1,
+            extensions: strs(&["nc", "cdf", "netcdf"]),
+            mimetypes: Some(strs(&["application/x-netcdf"])),
+            binary: "ncdump".to_string(),
+            args: strs(&["-h", "$input_virtual_path"]),
+            disabled_by_default: None,
+            match_only_by_mime: None,
+            output_path_hint: Some("${input_virtual_path}.txt".into()),
+        }
+        ,
+        CustomAdapterConfig {
+            name: "fitsdump".to_string(),
+            description: "Uses fitsdump to print FITS headers".to_string(),
+            version: 1,
+            extensions: strs(&["fits", "fit", "fts"]),
+            mimetypes: Some(strs(&["application/fits"])),
+            binary: "fitsdump".to_string(),
+            args: strs(&["-h", "$input_virtual_path"]),
+            disabled_by_default: None,
+            match_only_by_mime: None,
+            output_path_hint: Some("${input_virtual_path}.txt".into()),
+        }
+        ,
+        CustomAdapterConfig {
+            name: "dcmdump".to_string(),
+            description: "Uses dcmdump to print DICOM metadata and tags".to_string(),
+            version: 1,
+            extensions: strs(&["dcm"]),
+            mimetypes: Some(strs(&["application/dicom", "application/dicom+binary"])),
+            binary: "dcmdump".to_string(),
+            args: strs(&["+L", "$input_virtual_path"]),
+            disabled_by_default: None,
+            match_only_by_mime: None,
+            output_path_hint: Some("${input_virtual_path}.txt".into()),
+        }
+        ,
+        CustomAdapterConfig {
+            name: "7zlist".to_string(),
+            description: "Uses 7z to list archive contents for 7z/RAR".to_string(),
+            version: 1,
+            extensions: strs(&["7z", "rar"]),
+            mimetypes: Some(strs(&["application/x-7z-compressed", "application/x-rar-compressed", "application/vnd.rar"])),
+            binary: "7z".to_string(),
+            args: strs(&["l", "-slt", "$input_virtual_path"]),
+            disabled_by_default: None,
+            match_only_by_mime: None,
+            output_path_hint: Some("${input_virtual_path}.txt".into()),
+        }
+        ,
+        CustomAdapterConfig {
+            name: "exiftool".to_string(),
+            description: "Uses exiftool to extract rich metadata tags from images, video, audio, and PDFs".to_string(),
+            version: 1,
+            extensions: strs(&[
+                "jpg","jpeg","png","tif","tiff","gif","webp","heic","heif",
+                "mp4","mov","mkv","avi","webm","m4a","mp3","flac","wav","ogg","opus",
+                "pdf"
+            ]),
+            mimetypes: Some(strs(&[
+                "image/jpeg","image/png","image/tiff","image/gif","image/webp","image/heif",
+                "video/mp4","video/quicktime","video/x-matroska","video/x-msvideo","video/webm",
+                "audio/mpeg","audio/mp4","audio/flac","audio/wav","audio/ogg","audio/opus",
+                "application/pdf"
+            ])),
+            binary: "exiftool".to_string(),
+            args: strs(&["$input_virtual_path"]),
+            disabled_by_default: None,
+            match_only_by_mime: None,
+            output_path_hint: Some("${input_virtual_path}.txt".into()),
         }
     ];
 }
@@ -223,22 +323,7 @@ fn arg_replacer(arg: &str, filepath_hint: &Path) -> Result<String> {
         e => Err(anyhow::format_err!("unknown replacer ${{{e}}}")),
     })
 }
-impl CustomSpawningFileAdapter {
-    fn command(
-        &self,
-        filepath_hint: &std::path::Path,
-        mut command: tokio::process::Command,
-    ) -> Result<tokio::process::Command> {
-        command.args(
-            self.args
-                .iter()
-                .map(|arg| arg_replacer(arg, filepath_hint))
-                .collect::<Result<Vec<_>>>()?,
-        );
-        log::debug!("running command {:?}", command);
-        Ok(command)
-    }
-}
+impl CustomSpawningFileAdapter {}
 #[async_trait]
 impl FileAdapter for CustomSpawningFileAdapter {
     async fn adapt(
@@ -256,10 +341,29 @@ impl FileAdapter for CustomSpawningFileAdapter {
             ..
         } = ai;
 
-        let cmd = Command::new(&self.binary);
-        let cmd = self
-            .command(&filepath_hint, cmd)
-            .with_context(|| format!("Could not set cmd arguments for {}", self.binary))?;
+        let mut cmd = Command::new(&self.binary);
+        // Prefer file path invocation when is_real_file to allow faster random access
+        let args = self
+            .args
+            .iter()
+            .map(|arg| arg_replacer(arg, &filepath_hint))
+            .collect::<Result<Vec<_>>>()?;
+        let fh = filepath_hint.to_string_lossy();
+        if config.accurate && !args.iter().any(|a| a.contains(&*fh)) {
+            if self.binary == "pdftotext" && args.first().map(|s| s == "-").unwrap_or(false) {
+                let mut args2 = args.clone();
+                args2[0] = fh.to_string();
+                cmd.args(&args2);
+            } else if self.binary == "pandoc" && ai.is_real_file {
+                let mut args2 = args.clone();
+                args2.push(fh.to_string());
+                cmd.args(&args2);
+            } else {
+                cmd.args(&args);
+            }
+        } else {
+            cmd.args(&args);
+        }
         debug!("executing {:?}", cmd);
         let output = pipe_output(&line_prefix, cmd, inp, &self.binary, "")?;
         Ok(one_file(AdaptInfo {
@@ -330,7 +434,8 @@ mod test {
 
         let (a, d) = simple_adapt_info(&filepath, Box::pin(File::open(&filepath).await?));
         // let r = adapter.adapt(a, &d)?;
-        let r = loop_adapt(&adapter, d, a).await?;
+        let engine = crate::preproc::make_engine(&a.config)?;
+        let r = loop_adapt(engine, &adapter, d, a).await?;
         let o = adapted_to_vec(r).await?;
         assert_eq!(
             String::from_utf8(o)?,

--- a/src/adapters/postproc.rs
+++ b/src/adapters/postproc.rs
@@ -54,7 +54,7 @@ impl FileAdapter for PostprocPrefix {
     ) -> Result<AdaptedFilesIterBox> {
         let read = add_newline(postproc_prefix(
             &a.line_prefix,
-            postproc_encoding(&a.line_prefix, a.inp).await?,
+            postproc_encoding(&a.line_prefix, a.inp, &a.config).await?,
         ));
         // keep adapt info (filename etc) except replace inp
         let ai = AdaptInfo {
@@ -82,6 +82,7 @@ impl Read for ReadErr {
 async fn postproc_encoding(
     _line_prefix: &str,
     inp: Pin<Box<dyn AsyncRead + Send>>,
+    config: &crate::config::RgaConfig,
 ) -> Result<Pin<Box<dyn AsyncRead + Send>>> {
     // check for binary content in first 8kB
     // read the first 8kB into a buffer, check for null bytes, then return the buffer concatenated with the rest of the file
@@ -92,38 +93,39 @@ async fn postproc_encoding(
     let has_binary = fourk.contains(&0u8);
 
     let enc = Encoding::for_bom(&fourk);
-    let inp = Cursor::new(fourk).chain(beginning.into_inner());
+    let combined = Cursor::new(fourk).chain(beginning.into_inner());
     match enc {
         Some((enc, _)) if enc != encoding_rs::UTF_8 => {
-            // detected UTF16LE or UTF16BE, convert to UTF8 in separate thread
-            // TODO: parse these options from ripgrep's configuration
-            let encoding = None; // detect bom but usually assume utf8
+            let encoding = None;
             let bom_sniffing = true;
-            let mut decode_builder = DecodeReaderBytesBuilder::new();
-            // https://github.com/BurntSushi/ripgrep/blob/a7d26c8f144a4957b75f71087a66692d0b25759a/grep-searcher/src/searcher/mod.rs#L706
-            // this detects utf-16 BOMs and transcodes to utf-8 if they are present
-            // it does not detect any other char encodings. that would require https://github.com/hsivonen/chardetng or similar but then binary detection is hard (?)
-            let mut inp = decode_builder
+            let mut builder = DecodeReaderBytesBuilder::new();
+            let reader = builder
                 .encoding(encoding)
                 .utf8_passthru(true)
                 .strip_bom(bom_sniffing)
                 .bom_override(true)
                 .bom_sniffing(bom_sniffing)
-                .build(SyncIoBridge::new(inp));
-            let oup = tokio::task::spawn_blocking(move || -> Result<Vec<u8>> {
-                let mut oup = Vec::new();
-                std::io::Read::read_to_end(&mut inp, &mut oup)?;
-                Ok(oup)
-            })
-            .await??;
-            Ok(Box::pin(Cursor::new(oup)))
+                .build(SyncIoBridge::new(combined));
+            let (w, r) = tokio::io::duplex(config.postproc_pipe_bytes.0);
+            tokio::task::spawn_blocking(move || -> Result<()> {
+                let mut buf = [0u8; 1 << 17];
+                let mut rdr = reader;
+                let mut writer = SyncIoBridge::new(w);
+                loop {
+                    let n = std::io::Read::read(&mut rdr, &mut buf)?;
+                    if n == 0 { break; }
+                    std::io::Write::write_all(&mut writer, &buf[..n])?;
+                }
+                Ok(())
+            });
+            Ok(Box::pin(r))
         }
         _ => {
             if has_binary {
                 log::debug!("detected binary");
                 return Ok(Box::pin(Cursor::new("[rga: binary data]")));
             }
-            Ok(Box::pin(inp))
+            Ok(Box::pin(combined))
         }
     }
 }
@@ -133,9 +135,8 @@ pub fn postproc_prefix<T: AsyncRead + Send>(
     line_prefix: &str,
     inp: T,
 ) -> impl AsyncRead + Send + use<T> {
-    let line_prefix_n = format!("\n{line_prefix}"); // clone since we need it later
+    let line_prefix_n = format!("\n{line_prefix}");
     let line_prefix_o = Bytes::copy_from_slice(line_prefix.as_bytes());
-    let regex = regex::bytes::Regex::new("\n").unwrap();
     let inp_stream = ReaderStream::new(inp);
     let oup_stream = stream! {
         yield Ok(line_prefix_o);
@@ -144,7 +145,15 @@ pub fn postproc_prefix<T: AsyncRead + Send>(
                 Err(e) => yield Err(e),
                 Ok(chunk) => {
                     if chunk.contains(&b'\n') {
-                        yield Ok(Bytes::copy_from_slice(&regex.replace_all(&chunk, line_prefix_n.as_bytes())));
+                        let mut out = Vec::with_capacity(chunk.len() + 16);
+                        let mut last = 0usize;
+                        for pos in memchr::memchr_iter(b'\n', &chunk) {
+                            out.extend_from_slice(&chunk[last..pos]);
+                            out.extend_from_slice(line_prefix_n.as_bytes());
+                            last = pos + 1;
+                        }
+                        out.extend_from_slice(&chunk[last..]);
+                        yield Ok(Bytes::from(out));
                     } else {
                         yield Ok(chunk);
                     }
@@ -182,7 +191,11 @@ impl FileAdapter for PostprocPageBreaks {
         a: super::AdaptInfo,
         _detection_reason: &crate::matching::FileMatcher,
     ) -> Result<AdaptedFilesIterBox> {
-        let read = postproc_pagebreaks(postproc_encoding(&a.line_prefix, a.inp).await?);
+        let read: Pin<Box<dyn AsyncRead + Send>> = if a.config.disable_pagebreaks {
+            Box::pin(postproc_prefix(&a.line_prefix, postproc_encoding(&a.line_prefix, a.inp, &a.config).await?))
+        } else {
+            Box::pin(postproc_pagebreaks(postproc_encoding(&a.line_prefix, a.inp, &a.config).await?))
+        };
         // keep adapt info (filename etc) except replace inp
         let ai = AdaptInfo {
             inp: Box::pin(read),
@@ -202,41 +215,49 @@ impl FileAdapter for PostprocPageBreaks {
 /// where N starts at one and is incremented for each ASCII Form Feed character in the input stream.
 /// ASCII form feeds are the page delimiters output by `pdftotext`.
 pub fn postproc_pagebreaks(input: impl AsyncRead + Send) -> impl AsyncRead + Send {
-    let regex_linefeed = regex::bytes::Regex::new(r"\x0c").unwrap();
-    let regex_newline = regex::bytes::Regex::new("\n").unwrap();
     let mut page_count: i32 = 1;
     let mut page_prefix: String = format!("\nPage {page_count}: ");
-
     let input_stream = ReaderStream::new(input);
     let output_stream = stream! {
         yield std::io::Result::Ok(Bytes::copy_from_slice(format!("Page {page_count}: ").as_bytes()));
-        // store Page X: line prefixes in pending and only write it to the output when there is more text to be written
-        // this is needed since pdftotext outputs a \x0c at the end of the last page
         let mut pending: Option<Bytes> = None;
-
         for await read_chunk in input_stream {
             let read_chunk = read_chunk?;
-            let page_chunks = regex_linefeed.split(&read_chunk);
-            for (chunk_idx, page_chunk) in page_chunks.enumerate() {
-                if chunk_idx != 0 {
-                    page_count += 1;
-                    page_prefix = format!("\nPage {page_count}: ");
-                    if let Some(p) = pending.take() {
-                        yield Ok(p);
-                    }
-                    pending = Some(Bytes::copy_from_slice(page_prefix.as_bytes()));
-                }
+            let mut start = 0usize;
+            while let Some(ff_pos) = memchr::memchr(0x0c, &read_chunk[start..]) {
+                let abs = start + ff_pos;
+                let page_chunk = &read_chunk[start..abs];
                 if !page_chunk.is_empty() {
-                    if let Some(p) = pending.take() {
-                        yield Ok(p);
+                    if let Some(p) = pending.take() { yield Ok(p); }
+                    let mut out = Vec::with_capacity(page_chunk.len() + 16);
+                    let mut last = 0usize;
+                    for nl in memchr::memchr_iter(b'\n', page_chunk) {
+                        out.extend_from_slice(&page_chunk[last..nl]);
+                        out.extend_from_slice(page_prefix.as_bytes());
+                        last = nl + 1;
                     }
-                    yield Ok(Bytes::copy_from_slice(&regex_newline.replace_all(page_chunk, page_prefix.as_bytes())));
+                    out.extend_from_slice(&page_chunk[last..]);
+                    yield Ok(Bytes::from(out));
                 }
-
+                page_count += 1;
+                page_prefix = format!("\nPage {page_count}: ");
+                pending = Some(Bytes::copy_from_slice(page_prefix.as_bytes()));
+                start = abs + 1;
+            }
+            let page_chunk = &read_chunk[start..];
+            if !page_chunk.is_empty() {
+                if let Some(p) = pending.take() { yield Ok(p); }
+                let mut out = Vec::with_capacity(page_chunk.len() + 16);
+                let mut last = 0usize;
+                for nl in memchr::memchr_iter(b'\n', page_chunk) {
+                    out.extend_from_slice(&page_chunk[last..nl]);
+                    out.extend_from_slice(page_prefix.as_bytes());
+                    last = nl + 1;
+                }
+                out.extend_from_slice(&page_chunk[last..]);
+                yield Ok(Bytes::from(out));
             }
         }
-
-
     };
     Box::pin(StreamReader::new(output_stream))
 }
@@ -293,7 +314,8 @@ mod tests {
         let fname = test_data_dir().join("twoblankpages.pdf");
         let rd = File::open(&fname).await?;
         let (a, d) = simple_adapt_info(&fname, Box::pin(rd));
-        let res = loop_adapt(&adapter, d, a).await?;
+        let engine = crate::preproc::make_engine(&a.config)?;
+        let res = loop_adapt(engine, &adapter, d, a).await?;
 
         let buf = adapted_to_vec(res).await?;
 
@@ -339,7 +361,8 @@ PREFIX:Page 3:
     ) -> Result<()> {
         let mut oup = Vec::new();
         let inp = Box::pin(Cursor::new(a));
-        let inp = postproc_encoding("", inp).await?;
+        let cfg = crate::config::RgaConfig::default();
+        let inp = postproc_encoding("", inp, &cfg).await?;
         if pagebreaks {
             postproc_pagebreaks(inp).read_to_end(&mut oup).await?;
         } else {

--- a/src/adapters/tar.rs
+++ b/src/adapters/tar.rs
@@ -12,6 +12,11 @@ use log::*;
 use std::path::PathBuf;
 
 use tokio_stream::StreamExt;
+use tokio::sync::Semaphore;
+use tokio::io::{duplex, copy};
+use tokio::sync::mpsc;
+use std::time::Instant;
+use std::sync::Mutex;
 
 use super::{AdaptInfo, FileAdapter, GetMetadata};
 
@@ -32,6 +37,12 @@ lazy_static! {
         disabled_by_default: false
     };
 }
+lazy_static! { static ref TAR_PIPE_TUNED: Mutex<Option<usize>> = Mutex::new(None); }
+fn get_tar_pipe_bytes(cfg: &crate::config::RgaConfig) -> usize {
+    let mut g = TAR_PIPE_TUNED.lock().unwrap();
+    if let Some(v) = *g { v } else { let v = cfg.tar_pipe_bytes.0; *g = Some(v); v }
+}
+fn set_tar_pipe_bytes(new: usize) { let mut g = TAR_PIPE_TUNED.lock().unwrap(); *g = Some(new); }
 #[derive(Default, Clone)]
 pub struct TarAdapter;
 
@@ -63,8 +74,31 @@ impl FileAdapter for TarAdapter {
             ..
         } = ai;
         let mut archive = ::tokio_tar::Archive::new(inp);
-
         let mut entries = archive.entries()?;
+        let sem = std::sync::Arc::new(Semaphore::new(config.tar_max_concurrency.0));
+        let (tx, mut rx) = mpsc::unbounded_channel::<(usize, f64)>();
+        {
+            let min_cap: usize = 1<<18; // 256 KiB
+            let max_cap: usize = 1<<20; // 1 MiB
+            let cfg = config.clone();
+            tokio::spawn(async move {
+                let mut samples: Vec<(usize, f64)> = Vec::new();
+                let mut cur = get_tar_pipe_bytes(&cfg);
+                while let Some(s) = rx.recv().await {
+                    samples.push(s);
+                    if samples.len() >= 8 {
+                        let mut sum = 0.0f64;
+                        for (_, secs) in samples.iter() { sum += *secs; }
+                        let avg = sum / (samples.len() as f64);
+                        let mut new = cur;
+                        if avg > 0.2 { new = (cur.saturating_mul(2)).min(max_cap); }
+                        else if avg < 0.05 { new = (cur.saturating_div(2)).max(min_cap); }
+                        if new != cur { set_tar_pipe_bytes(new); cur = new; }
+                        samples.clear();
+                    }
+                }
+            });
+        }
         let s = stream! {
             while let Some(entry) = entries.next().await {
                 let file = entry?;
@@ -77,16 +111,27 @@ impl FileAdapter for TarAdapter {
                         print_bytes(file.header().size().unwrap_or(0) as f64),
                     );
                     let line_prefix = &format!("{}{}: ", line_prefix, path.display());
-                    let ai2: AdaptInfo = AdaptInfo {
+                    let (w, r) = duplex(get_tar_pipe_bytes(&config));
+                    let sem2 = sem.clone();
+                    let tx2 = tx.clone();
+                    tokio::spawn(async move {
+                        let _p = sem2.acquire_owned().await.unwrap();
+                        let mut src = file;
+                        let mut dst = w;
+                        let start = Instant::now();
+                        let n = copy(&mut src, &mut dst).await.unwrap_or(0);
+                        let secs = (Instant::now() - start).as_secs_f64();
+                        let _ = tx2.send((n as usize, secs));
+                    });
+                    yield Ok(AdaptInfo {
                         filepath_hint: path,
                         is_real_file: false,
                         archive_recursion_depth: archive_recursion_depth + 1,
-                        inp: Box::pin(file),
+                        inp: Box::pin(r),
                         line_prefix: line_prefix.to_string(),
                         config: config.clone(),
                         postprocess,
-                    };
-                    yield Ok(ai2);
+                    });
                 }
             }
         };
@@ -109,7 +154,8 @@ mod tests {
         let (a, d) = simple_adapt_info(&filepath, Box::pin(File::open(&filepath).await?));
 
         let adapter = TarAdapter::new();
-        let r = loop_adapt(&adapter, d, a).await.context("adapt")?;
+        let engine = crate::preproc::make_engine(&a.config)?;
+        let r = loop_adapt(engine, &adapter, d, a).await.context("adapt")?;
         let o = adapted_to_vec(r).await.context("adapted_to_vec")?;
         assert_eq!(
             String::from_utf8(o).context("parsing utf8")?,

--- a/src/adapters/writing.rs
+++ b/src/adapters/writing.rs
@@ -52,7 +52,7 @@ where
         detection_reason: &crate::matching::FileMatcher,
     ) -> Result<crate::adapted_iter::AdaptedFilesIterBox> {
         let name = self.metadata().name.clone();
-        let (w, r) = tokio::io::duplex(128 * 1024);
+        let (w, r) = tokio::io::duplex(a.config.writing_pipe_bytes.0);
         let d2 = detection_reason.clone();
         let archive_recursion_depth = a.archive_recursion_depth + 1;
         let filepath_hint = format!("{}.txt", a.filepath_hint.to_string_lossy());

--- a/src/bin/rga-preproc.rs
+++ b/src/bin/rga-preproc.rs
@@ -13,7 +13,11 @@ async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let mut arg_arr: Vec<std::ffi::OsString> = std::env::args_os().collect();
     let last = arg_arr.pop().expect("No filename specified");
-    let config = rga::config::parse_args(arg_arr, true)?;
+    let mut config = rga::config::parse_args(arg_arr, true)?;
+    if config.decompress_autotune_import.is_none()
+        && let Ok(p) = std::env::var("RGA_DECOMPRESS_AUTOTUNE_IMPORT")
+        && !p.is_empty() { config.decompress_autotune_import = Some(p); }
+    if let Some(p) = config.decompress_autotune_import.as_ref() { let _ = rga::adapters::decompress::import_caps_from_file(p); }
     //clap::App::new("rga-preproc").arg(Arg::from_usage())
     let path = {
         let filepath = last;
@@ -31,7 +35,7 @@ async fn main() -> anyhow::Result<()> {
         line_prefix: "".to_string(),
         archive_recursion_depth: 0,
         postprocess: !config.no_prefix_filenames,
-        config,
+        config: config.clone(),
     };
 
     let start = Instant::now();
@@ -47,5 +51,10 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     debug!("running adapter took {} total", print_dur(start));
+    if config.decompress_autotune_export.is_none()
+        && let Ok(p) = std::env::var("RGA_DECOMPRESS_AUTOTUNE_EXPORT")
+        && !p.is_empty() { config.decompress_autotune_export = Some(p); }
+    if let Some(p) = config.decompress_autotune_export.as_ref() { let _ = rga::adapters::decompress::export_caps_to_file(p); }
+    if config.profile { println!("{}", rga::preproc::prof_summary()); }
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
 use std::io::Read;
 use std::{fs::File, io::Write, iter::IntoIterator, path::PathBuf, str::FromStr};
-use structopt::StructOpt;
+use clap::Parser;
+use serde::Deserialize as DeDeserialize;
 
 fn is_default<T: Default + PartialEq>(t: &T) -> bool {
     t == &T::default()
@@ -22,7 +23,7 @@ impl std::fmt::Display for CacheCompressionLevel {
 }
 impl Default for CacheCompressionLevel {
     fn default() -> Self {
-        Self(12)
+        Self(8)
     }
 }
 #[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr)]
@@ -38,6 +39,131 @@ impl Default for MaxArchiveRecursion {
         Self(5)
     }
 }
+
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr)]
+pub struct ZipMaxConcurrency(pub usize);
+impl std::fmt::Display for ZipMaxConcurrency { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "{}", self.0) } }
+impl Default for ZipMaxConcurrency {
+
+
+    fn default() -> Self {
+        Self(8)
+    }
+}
+
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr)]
+pub struct ZipPipeBytes(pub usize);
+impl std::fmt::Display for ZipPipeBytes { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "{}", self.0) } }
+impl Default for ZipPipeBytes {
+    fn default() -> Self {
+        Self(524288)
+    }
+}
+
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr)]
+pub struct TarMaxConcurrency(pub usize);
+impl std::fmt::Display for TarMaxConcurrency { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "{}", self.0) } }
+impl Default for TarMaxConcurrency { fn default() -> Self { Self(1) } }
+
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr)]
+pub struct TarPipeBytes(pub usize);
+impl std::fmt::Display for TarPipeBytes { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "{}", self.0) } }
+impl Default for TarPipeBytes { fn default() -> Self { Self(524288) } }
+
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr)]
+pub struct WritingPipeBytes(pub usize);
+impl std::fmt::Display for WritingPipeBytes { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "{}", self.0) } }
+impl Default for WritingPipeBytes { fn default() -> Self { Self(512 * 1024) } }
+
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr)]
+pub struct PostprocPipeBytes(pub usize);
+impl std::fmt::Display for PostprocPipeBytes { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "{}", self.0) } }
+impl Default for PostprocPipeBytes {
+    fn default() -> Self {
+        Self(524288)
+    }
+}
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr)]
+pub struct DecompressGzipBufBytes(pub usize);
+
+impl std::fmt::Display for DecompressGzipBufBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl Default for DecompressGzipBufBytes {
+    fn default() -> Self {
+        Self(524288)
+    }
+}
+
+
+
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr)]
+pub struct DecompressBzip2BufBytes(pub usize);
+
+impl std::fmt::Display for DecompressBzip2BufBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl Default for DecompressBzip2BufBytes {
+    fn default() -> Self {
+        Self(262144)
+    }
+}
+
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr)]
+pub struct DecompressXzBufBytes(pub usize);
+
+impl std::fmt::Display for DecompressXzBufBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl Default for DecompressXzBufBytes {
+    fn default() -> Self {
+        Self(262144)
+    }
+}
+
+
+
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr)]
+pub struct DecompressZstdBufBytes(pub usize);
+
+impl std::fmt::Display for DecompressZstdBufBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl Default for DecompressZstdBufBytes {
+    fn default() -> Self {
+        Self(524288)
+    }
+}
+
+
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr, Default)]
+pub struct MemCapBytes(pub usize);
+
+impl std::fmt::Display for MemCapBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+ 
+
+
+#[derive(JsonSchema, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, FromStr, Default)]
+pub struct CacheSmallUncompressedBytes(pub usize);
+
+impl std::fmt::Display for CacheSmallUncompressedBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+// default derives from #[derive(Default)] above
 
 #[derive(JsonSchema, Debug, Serialize, Deserialize, Clone, PartialEq, FromStr)]
 pub struct CachePath(pub String);
@@ -100,16 +226,15 @@ impl FromStr for CacheMaxBlobLen {
 /// 1. Declare the command line arguments using structopt+clap
 /// 1. Provide information for manpage / readme generation.
 /// 1. Describe the config file format (output as JSON schema via schemars).
-#[derive(StructOpt, Debug, Deserialize, Serialize, JsonSchema, Default, Clone)]
-#[structopt(
+#[derive(Parser, Debug, Deserialize, Serialize, JsonSchema, Default, Clone)]
+#[command(
     name = "ripgrep-all",
     rename_all = "kebab-case",
     about = env!("CARGO_PKG_DESCRIPTION"),
     author = env!("CARGO_PKG_HOMEPAGE"),
     long_about="rga: ripgrep, but also search in PDFs, E-Books, Office documents, zip, tar.gz, etc.",
-    // TODO: long_about does not seem to work to only show this on short help
     after_help = "-h shows a concise overview, --help shows more detail and advanced options.\n\nAll other options not shown here are passed directly to rg, especially [PATTERN] and [PATH ...]",
-    usage = "rga [RGA OPTIONS] [RG OPTIONS] PATTERN [PATH ...]"
+    override_usage = "rga [RGA OPTIONS] [RG OPTIONS] PATTERN [PATH ...]"
 )]
 pub struct RgaConfig {
     /// Use more accurate but slower matching by mime type.
@@ -119,7 +244,7 @@ pub struct RgaConfig {
     /// With this flag, rga will try to detect the mime type of input files using the magic bytes (similar to the `file` utility), and use that to choose the adapter.
     /// Detection is only done on the first 8KiB of the file, since we can't always seek on the input (in archives).
     #[serde(default, skip_serializing_if = "is_default")]
-    #[structopt(long = "--rga-accurate")]
+    #[arg(long = "rga-accurate")]
     pub accurate: bool,
 
     /// Change which adapters to use and in which priority order (descending).
@@ -128,15 +253,15 @@ pub struct RgaConfig {
     /// - "-bar,baz" means use all default adapters except for bar and baz.
     /// - "+bar,baz" means use all default adapters and also bar and baz.
     #[serde(default, skip_serializing_if = "is_default")]
-    #[structopt(
-        long = "--rga-adapters",
+    #[arg(
+        long = "rga-adapters",
         require_equals = true,
-        require_delimiter = true
+        value_delimiter = ','
     )]
     pub adapters: Vec<String>,
 
     #[serde(default, skip_serializing_if = "is_default")]
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub cache: CacheConfig,
 
     /// Maximum depth of nested archives to recurse into.
@@ -144,11 +269,11 @@ pub struct RgaConfig {
     /// When searching in archives, rga will recurse into archives inside archives.
     /// This option limits the depth.
     #[serde(default, skip_serializing_if = "is_default")]
-    #[structopt(
-        default_value,
-        long = "--rga-max-archive-recursion",
+    #[arg(
+        default_value_t,
+        long = "rga-max-archive-recursion",
         require_equals = true,
-        hidden_short_help = true
+        hide_short_help = true
     )]
     pub max_archive_recursion: MaxArchiveRecursion,
 
@@ -157,46 +282,202 @@ pub struct RgaConfig {
     /// Inside archives, by default rga prefixes the content of each file with the file path within the archive.
     /// This is usually useful, but can cause problems because then the inner path is also searched for the pattern.
     #[serde(default, skip_serializing_if = "is_default")]
-    #[structopt(long = "--rga-no-prefix-filenames")]
+    #[arg(long = "rga-no-prefix-filenames")]
     pub no_prefix_filenames: bool,
 
     #[serde(default, skip_serializing_if = "is_default")]
-    #[structopt(skip)] // config file only
+    #[arg(
+        default_value_t,
+        long = "rga-zip-max-concurrency",
+        require_equals = true,
+        hide_short_help = true
+    )]
+    pub zip_max_concurrency: ZipMaxConcurrency,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(
+        default_value_t,
+        long = "rga-zip-pipe-bytes",
+        require_equals = true,
+        hide_short_help = true
+    )]
+    pub zip_pipe_bytes: ZipPipeBytes,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(
+        default_value_t,
+        long = "rga-writing-pipe-bytes",
+        require_equals = true,
+        hide_short_help = true
+    )]
+    pub writing_pipe_bytes: WritingPipeBytes,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(
+        default_value_t,
+        long = "rga-postproc-pipe-bytes",
+        require_equals = true,
+        hide_short_help = true
+    )]
+    pub postproc_pipe_bytes: PostprocPipeBytes,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(long = "rga-zip-owned-iter")]
+    pub zip_owned_iter: bool,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(
+        default_value_t,
+        long = "rga-tar-max-concurrency",
+        require_equals = true,
+        hide_short_help = true
+    )]
+    pub tar_max_concurrency: TarMaxConcurrency,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(
+        default_value_t,
+        long = "rga-tar-pipe-bytes",
+        require_equals = true,
+        hide_short_help = true
+    )]
+    pub tar_pipe_bytes: TarPipeBytes,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(
+        default_value_t,
+        long = "rga-decompress-gzip-buf-bytes",
+        require_equals = true,
+        hide_short_help = true
+    )]
+    pub decompress_gzip_buf_bytes: DecompressGzipBufBytes,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(
+        default_value_t,
+        long = "rga-decompress-bzip2-buf-bytes",
+        require_equals = true,
+        hide_short_help = true
+    )]
+    pub decompress_bzip2_buf_bytes: DecompressBzip2BufBytes,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(
+        default_value_t,
+        long = "rga-decompress-xz-buf-bytes",
+        require_equals = true,
+        hide_short_help = true
+    )]
+    pub decompress_xz_buf_bytes: DecompressXzBufBytes,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(
+        default_value_t,
+        long = "rga-decompress-zstd-buf-bytes",
+        require_equals = true,
+        hide_short_help = true
+    )]
+    pub decompress_zstd_buf_bytes: DecompressZstdBufBytes,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(long = "rga-decompress-autotune")]
+    pub decompress_autotune: bool,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(long = "rga-decompress-autotune-export", require_equals = true)]
+    pub decompress_autotune_export: Option<String>,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(long = "rga-decompress-autotune-import", require_equals = true)]
+    pub decompress_autotune_import: Option<String>,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(skip)] // config file only
     pub custom_adapters: Option<Vec<CustomAdapterConfig>>,
 
     #[serde(skip)]
-    #[structopt(long = "--rga-config-file", require_equals = true)]
+    #[arg(long = "rga-config-file", require_equals = true)]
     pub config_file_path: Option<String>,
+
+    #[serde(skip)]
+    #[arg(long = "rga-load-sweep", require_equals = true)]
+    pub load_sweep_path: Option<String>,
 
     /// Same as passing path directly, except if argument is empty.
     ///
     /// Kinda hacky, but if no file is found, `fzf` calls `rga` with empty string as path, which causes "No such file or directory from rg".
     /// So filter those cases and return specially.
     #[serde(skip)] // CLI only
-    #[structopt(long = "--rga-fzf-path", require_equals = true, hidden = true)]
+    #[arg(long = "rga-fzf-path", require_equals = true, hide = true)]
     pub fzf_path: Option<String>,
 
     #[serde(skip)] // CLI only
-    #[structopt(long = "--rga-list-adapters", help = "List all known adapters")]
+    #[arg(long = "rga-list-adapters", help = "List all known adapters")]
     pub list_adapters: bool,
 
+    #[serde(skip)]
+    #[arg(long = "rga-cache-build")]
+    pub cache_build: bool,
+
     #[serde(skip)] // CLI only
-    #[structopt(
-        long = "--rga-print-config-schema",
+    #[arg(
+        long = "rga-print-config-schema",
         help = "Print the JSON Schema of the configuration file"
     )]
     pub print_config_schema: bool,
 
     #[serde(skip)] // CLI only
-    #[structopt(long, help = "Show help for ripgrep itself")]
+    #[arg(long, help = "Show help for ripgrep itself")]
     pub rg_help: bool,
 
     #[serde(skip)] // CLI only
-    #[structopt(long, help = "Show version of ripgrep itself")]
+    #[arg(long, help = "Show version of ripgrep itself")]
     pub rg_version: bool,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(long = "rga-profile")]
+    pub profile: bool,
+
+    #[serde(skip)]
+    #[arg(long = "rga-doctor")]
+    pub doctor: bool,
+
+    #[serde(skip)]
+    #[arg(long = "rga-max-rss-bytes", require_equals = true)]
+    pub max_rss_bytes: Option<usize>,
+
+    #[serde(skip)]
+    #[arg(long = "rga-max-file-bytes", require_equals = true)]
+    pub max_file_bytes: Option<usize>,
+
+    #[serde(skip)]
+    #[arg(long = "rga-cache-prune")]
+    pub cache_prune: bool,
+
+    #[serde(skip)]
+    #[arg(long = "rga-cache-prune-max-bytes", require_equals = true)]
+    pub cache_prune_max_bytes: Option<String>,
+
+    #[serde(skip)]
+    #[arg(long = "rga-cache-prune-ttl-days", require_equals = true)]
+    pub cache_prune_ttl_days: Option<i32>,
+
+    /// Disable page break postprocessing (removes "Page N:" prefixes)
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(long = "rga-disable-pagebreaks")]
+    pub disable_pagebreaks: bool,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(long = "rga-ipynb-include-outputs")]
+    pub ipynb_include_outputs: bool,
+
+    /// Disable line prefixing for specific adapters (comma-delimited names)
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(long = "rga-no-prefix-for", require_equals = true, value_delimiter = ',')]
+    pub no_prefix_for_adapters: Vec<String>,
 }
 
-#[derive(StructOpt, Debug, Deserialize, Serialize, JsonSchema, Default, Clone, PartialEq)]
+#[derive(Parser, Debug, Deserialize, Serialize, JsonSchema, Default, Clone, PartialEq)]
 pub struct CacheConfig {
     /// Disable caching of results.
     ///
@@ -209,7 +490,7 @@ pub struct CacheConfig {
     ///
     /// If you pass this flag, all caching will be disabled.
     #[serde(default, skip_serializing_if = "is_default")]
-    #[structopt(long = "--rga-no-cache")]
+    #[arg(long = "rga-no-cache")]
     pub disabled: bool,
 
     /// Max compressed size to cache.
@@ -219,10 +500,10 @@ pub struct CacheConfig {
     ///
     /// Allowed suffixes on command line: k M G
     #[serde(default, skip_serializing_if = "is_default")]
-    #[structopt(
-        default_value,
-        long = "--rga-cache-max-blob-len",
-        hidden_short_help = true,
+    #[arg(
+        default_value_t,
+        long = "rga-cache-max-blob-len",
+        hide_short_help = true,
         require_equals = true,
         // parse(try_from_str = parse_readable_bytes_str)
     )]
@@ -232,10 +513,10 @@ pub struct CacheConfig {
     ///
     /// Ranges from 1 - 22.
     #[serde(default, skip_serializing_if = "is_default")]
-    #[structopt(
-        default_value,
-        long = "--rga-cache-compression-level",
-        hidden_short_help = true,
+    #[arg(
+        default_value_t,
+        long = "rga-cache-compression-level",
+        hide_short_help = true,
         require_equals = true,
         help = ""
     )]
@@ -243,13 +524,31 @@ pub struct CacheConfig {
 
     /// Path to store cache DB.
     #[serde(default, skip_serializing_if = "is_default")]
-    #[structopt(
-        default_value,
-        long = "--rga-cache-path",
-        hidden_short_help = true,
+    #[arg(
+        default_value_t,
+        long = "rga-cache-path",
+        hide_short_help = true,
         require_equals = true
     )]
     pub path: CachePath,
+
+    /// Zstd dictionary path for cache compression warm start
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(long = "rga-cache-dict-path", require_equals = true)]
+    pub dict_path: Option<String>,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(
+        default_value_t,
+        long = "rga-cache-small-uncompressed",
+        hide_short_help = true,
+        require_equals = true
+    )]
+    pub small_uncompressed_bytes: CacheSmallUncompressedBytes,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[arg(long = "rga-cache-no-small-uncompressed")]
+    pub disable_small_uncompressed: bool,
 }
 
 static RGA_CONFIG: &str = "RGA_CONFIG";
@@ -274,7 +573,7 @@ fn read_config_file(path_override: Option<String>) -> Result<(String, Value)> {
     let config_filename = path_override
         .as_ref()
         .map(PathBuf::from)
-        .unwrap_or_else(|| config_dir.join("config.jsonc"));
+        .unwrap_or_else(|| config_dir.join("config.json"));
     let config_filename_str = config_filename.to_string_lossy().into_owned();
     if config_filename.exists() {
         let config_file_contents = {
@@ -330,7 +629,7 @@ where
 {
     // TODO: don't read config file in rga-preproc for performance (called for every file)
 
-    let arg_matches: RgaConfig = RgaConfig::from_iter(args);
+    let arg_matches: RgaConfig = RgaConfig::parse_from(args);
     let args_config = serde_json::to_value(&arg_matches)?;
 
     let merged_config = {
@@ -382,15 +681,80 @@ where
         res.print_config_schema = arg_matches.print_config_schema;
         res.rg_help = arg_matches.rg_help;
         res.rg_version = arg_matches.rg_version;
+        let auto_sweep_path = if arg_matches.load_sweep_path.is_some() {
+            arg_matches.load_sweep_path.clone()
+        } else {
+            project_dirs().ok().and_then(|pd| {
+                // Prefer autoconfig.txt; fall back to sweep-results.toml
+                let rec = pd.cache_dir().join("autoconfig.txt");
+                if std::fs::metadata(&rec).is_ok() { return Some(rec.to_string_lossy().to_string()); }
+                let p = pd.cache_dir().join("sweep-results.toml");
+                if std::fs::metadata(&p).is_ok() { Some(p.to_string_lossy().to_string()) } else { None }
+            })
+        };
+        let auto_sweep_path = if auto_sweep_path.is_some() { auto_sweep_path } else {
+            project_dirs().ok().and_then(|pd| {
+                let rec = pd.cache_dir().join("autoconfig.txt");
+                if std::fs::metadata(&rec).is_err()
+                    && let Ok(exe) = std::env::current_exe()
+                    && let Some(dir) = exe.parent()
+                {
+                    let cand = if cfg!(windows) { dir.join("bench-sweep.exe") } else { dir.join("bench-sweep") };
+                    if std::fs::metadata(&cand).is_ok() {
+                        let _ = std::fs::create_dir_all(pd.cache_dir());
+                        let _ = std::process::Command::new(cand).args(["--out-txt", rec.to_string_lossy().as_ref()]).status();
+                    }
+                }
+                if std::fs::metadata(&rec).is_ok() { Some(rec.to_string_lossy().to_string()) } else { None }
+            })
+        };
+        if let Some(path) = auto_sweep_path.as_ref() {
+            if path.ends_with(".toml") {
+                #[derive(DeDeserialize)]
+                struct ZipSec { best_concurrency: usize, best_pipe_bytes: usize }
+                #[derive(DeDeserialize)]
+                struct ZipModeSec { owned_iter: bool }
+                #[derive(DeDeserialize)]
+                struct PostprocSec { best_pipe_bytes: usize }
+                #[derive(DeDeserialize)]
+                struct BufSec { best_buf_bytes: usize }
+                #[derive(DeDeserialize)]
+                struct ResultsToml { zip: ZipSec, zip_mode: ZipModeSec, postproc: PostprocSec, zstd: BufSec, gzip: BufSec, xz: BufSec, bzip2: BufSec }
+                let txt = std::fs::read_to_string(path).with_context(|| format!("reading sweep toml {path}"))?;
+                let r: ResultsToml = toml::from_str(&txt).with_context(|| "parsing sweep toml" )?;
+                res.zip_max_concurrency = ZipMaxConcurrency(r.zip.best_concurrency);
+                res.zip_pipe_bytes = ZipPipeBytes(r.zip.best_pipe_bytes);
+                res.zip_owned_iter = r.zip_mode.owned_iter;
+                res.postproc_pipe_bytes = PostprocPipeBytes(r.postproc.best_pipe_bytes);
+                res.decompress_zstd_buf_bytes = DecompressZstdBufBytes(r.zstd.best_buf_bytes);
+                res.decompress_gzip_buf_bytes = DecompressGzipBufBytes(r.gzip.best_buf_bytes);
+                res.decompress_xz_buf_bytes = DecompressXzBufBytes(r.xz.best_buf_bytes);
+                res.decompress_bzip2_buf_bytes = DecompressBzip2BufBytes(r.bzip2.best_buf_bytes);
+            } else {
+                let txt = std::fs::read_to_string(path).with_context(|| format!("reading sweep txt {path}"))?;
+                for tok in txt.split(|c: char| [' ', ',', '\n'].contains(&c)) {
+                    if let Some((k, v)) = tok.split_once('=') {
+                        match k {
+                            "rga-zip-max-concurrency" => if let Ok(u) = v.parse::<usize>() { res.zip_max_concurrency = ZipMaxConcurrency(u); },
+                            "rga-zip-pipe-bytes" => if let Ok(u) = v.parse::<usize>() { res.zip_pipe_bytes = ZipPipeBytes(u); },
+                            "rga-zip-owned-iter" => if let Ok(b) = v.parse::<bool>() { res.zip_owned_iter = b; },
+                            "rga-postproc-pipe-bytes" => if let Ok(u) = v.parse::<usize>() { res.postproc_pipe_bytes = PostprocPipeBytes(u); },
+                            "rga-decompress-zstd-buf-bytes" => if let Ok(u) = v.parse::<usize>() { res.decompress_zstd_buf_bytes = DecompressZstdBufBytes(u); },
+                            "rga-decompress-gzip-buf-bytes" => if let Ok(u) = v.parse::<usize>() { res.decompress_gzip_buf_bytes = DecompressGzipBufBytes(u); },
+                            "rga-decompress-xz-buf-bytes" => if let Ok(u) = v.parse::<usize>() { res.decompress_xz_buf_bytes = DecompressXzBufBytes(u); },
+                            "rga-decompress-bzip2-buf-bytes" => if let Ok(u) = v.parse::<usize>() { res.decompress_bzip2_buf_bytes = DecompressBzip2BufBytes(u); },
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
     }
     Ok(res)
 }
 
 /// Split arguments into the ones we care about and the ones rg cares about
 pub fn split_args(is_rga_preproc: bool) -> Result<(RgaConfig, Vec<OsString>)> {
-    let mut app = RgaConfig::clap();
-
-    app.p.create_help_and_version();
     let mut firstarg = true;
     // debug!("{:#?}", app.p.flags);
     let (our_args, mut passthrough_args): (Vec<OsString>, Vec<OsString>) = std::env::args_os()

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -5,7 +5,6 @@ use crate::adapters::*;
 
 use anyhow::*;
 
-use regex::{Regex, RegexSet};
 
 use std::iter::Iterator;
 
@@ -48,88 +47,66 @@ pub struct FileMeta {
     pub mimetype: Option<&'static str>,
 }
 
-pub fn extension_to_regex(extension: &str) -> Regex {
-    Regex::new(&format!("(?i)\\.{}$", &regex::escape(extension)))
-        .expect("we know this regex compiles")
-}
 
 #[allow(clippy::type_complexity)]
 pub fn adapter_matcher(
     adapters: &[Arc<dyn FileAdapter>],
     slow: bool,
-) -> Result<impl Fn(FileMeta) -> Option<(Arc<dyn FileAdapter>, FileMatcher)> + use<>> {
-    // need order later
+) -> Result<Box<dyn Fn(FileMeta) -> Option<(Arc<dyn FileAdapter>, FileMatcher)> + Send + Sync>> {
     let adapter_names: Vec<String> = adapters.iter().map(|e| e.metadata().name.clone()).collect();
-    let mut fname_regexes = vec![];
-    let mut mime_regexes = vec![];
+    let mut ext_map: std::collections::HashMap<String, Vec<(Arc<dyn FileAdapter>, FileMatcher)>> =
+        std::collections::HashMap::new();
+    let mut mime_map: std::collections::HashMap<String, Vec<(Arc<dyn FileAdapter>, FileMatcher)>> =
+        std::collections::HashMap::new();
     for adapter in adapters.iter() {
         let metadata = adapter.metadata();
-        use FileMatcher::*;
         for matcher in metadata.get_matchers(slow) {
             match matcher.as_ref() {
-                MimeType(re) => {
-                    mime_regexes.push((re.clone(), adapter.clone(), MimeType(re.clone())))
+                FileMatcher::MimeType(m) => {
+                    let k = m.to_string();
+                    mime_map
+                        .entry(k)
+                        .or_default()
+                        .push((adapter.clone(), FileMatcher::MimeType(m.clone())));
                 }
-                Fast(FastFileMatcher::FileExtension(re)) => fname_regexes.push((
-                    extension_to_regex(re),
-                    adapter.clone(),
-                    Fast(FastFileMatcher::FileExtension(re.clone())),
-                )),
-            };
+                FileMatcher::Fast(FastFileMatcher::FileExtension(ext)) => {
+                    let k = ext.to_ascii_lowercase();
+                    ext_map
+                        .entry(k)
+                        .or_default()
+                        .push((adapter.clone(), FileMatcher::Fast(FastFileMatcher::FileExtension(ext.clone()))));
+                }
+            }
         }
     }
-    let fname_regex_set = RegexSet::new(fname_regexes.iter().map(|p| p.0.as_str()))?;
-    let mime_regex_set = RegexSet::new(mime_regexes.iter().map(|p| p.0.as_str()))?;
-    Ok(move |meta: FileMeta| {
-        let fname_matches: Vec<_> = fname_regex_set
-            .matches(&meta.lossy_filename)
-            .into_iter()
-            .collect();
-        let mime_matches: Vec<_> = if slow {
-            mime_regex_set
-                .matches(meta.mimetype.expect("No mimetype?"))
-                .into_iter()
-                .collect()
-        } else {
-            vec![]
-        };
-        if fname_matches.len() + mime_matches.len() > 1 {
-            // get first according to original priority list...
-            // todo: kinda ugly
-            let fa = fname_matches
-                .iter()
-                .map(|e| (fname_regexes[*e].1.clone(), fname_regexes[*e].2.clone()));
-            let fb = mime_matches
-                .iter()
-                .map(|e| (mime_regexes[*e].1.clone(), mime_regexes[*e].2.clone()));
-            let mut v = vec![];
-            v.extend(fa);
-            v.extend(fb);
-            v.sort_by_key(|e| {
+    let func = move |meta: FileMeta| {
+        let ext = std::path::Path::new(&meta.lossy_filename)
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase());
+        let mut candidates: Vec<(Arc<dyn FileAdapter>, FileMatcher)> = vec![];
+        if let Some(ext) = ext && let Some(v) = ext_map.get(&ext) {
+            candidates.extend(v.iter().cloned());
+        }
+        if slow && let Some(mt) = meta.mimetype && let Some(v) = mime_map.get(mt) {
+            candidates.extend(v.iter().cloned());
+        }
+        if candidates.is_empty() {
+            return None;
+        }
+        if candidates.len() > 1 {
+            candidates.sort_by_key(|e| {
                 adapter_names
                     .iter()
                     .position(|r| r == &e.0.metadata().name)
-                    .expect("impossib7")
+                    .unwrap_or(usize::MAX)
             });
-            eprintln!(
-                "Warning: found multiple adapters for {}:",
-                meta.lossy_filename
-            );
-            for mmatch in v.iter() {
+            eprintln!("Warning: found multiple adapters for {}:", meta.lossy_filename);
+            for mmatch in candidates.iter() {
                 eprintln!(" - {}", mmatch.0.metadata().name);
             }
-            return Some(v[0].clone());
         }
-        if mime_matches.is_empty() {
-            if fname_matches.is_empty() {
-                None
-            } else {
-                let (_, adapter, matcher) = &fname_regexes[fname_matches[0]];
-                Some((adapter.clone(), matcher.clone()))
-            }
-        } else {
-            let (_, adapter, matcher) = &mime_regexes[mime_matches[0]];
-            Some((adapter.clone(), matcher.clone()))
-        }
-    })
+        Some(candidates.remove(0))
+    };
+    Ok(Box::new(func))
 }

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -1,6 +1,7 @@
 use crate::adapted_iter::AdaptedFilesIterBox;
 use crate::adapters::*;
 use crate::caching_writer::async_read_and_write_to_cache;
+use crate::caching_writer::load_zstd_dict_path;
 use crate::config::RgaConfig;
 use crate::matching::*;
 use crate::preproc_cache::CacheKey;
@@ -23,48 +24,104 @@ use std::sync::Arc;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
 use tokio::io::{AsyncBufRead, AsyncReadExt};
+use std::collections::HashMap;
+use std::sync::Mutex;
+use lazy_static::lazy_static;
 
 pub type ActiveAdapters = Vec<Arc<dyn FileAdapter>>;
 
+type MatcherFn = dyn Fn(FileMeta) -> Option<(Arc<dyn FileAdapter>, FileMatcher)> + Send + Sync;
+
+#[derive(Clone)]
+pub struct AdapterEngine {
+    pub active_adapters: ActiveAdapters,
+    pub matcher: std::sync::Arc<MatcherFn>,
+}
+
+pub fn make_engine(config: &RgaConfig) -> Result<AdapterEngine> {
+    if let Some(p) = &config.cache.dict_path {
+        let _ = load_zstd_dict_path(p);
+    }
+    let active_adapters = get_adapters_filtered(config.custom_adapters.clone(), &config.adapters)?;
+    let matcher_box = adapter_matcher(&active_adapters, config.accurate)?;
+    let matcher: std::sync::Arc<MatcherFn> = matcher_box.into();
+    Ok(AdapterEngine { active_adapters, matcher })
+}
+
+#[derive(Default, Clone)]
+struct AdapterStat { runs: u64, cache_hits: u64, cache_misses: u64, bytes_uncompressed: u64, bytes_compressed: u64 }
+lazy_static! { static ref PROF_STATS: Mutex<HashMap<String, AdapterStat>> = Mutex::new(HashMap::new()); }
+fn prof_hit(adapter: &str) {
+    let mut g = PROF_STATS.lock().unwrap();
+    let e = g.entry(adapter.to_string()).or_default();
+    e.runs += 1; e.cache_hits += 1;
+}
+fn prof_miss(adapter: &str, uncompressed: u64, compressed: Option<usize>) {
+    let mut g = PROF_STATS.lock().unwrap();
+    let e = g.entry(adapter.to_string()).or_default();
+    e.runs += 1; e.cache_misses += 1; e.bytes_uncompressed += uncompressed; if let Some(c) = compressed { e.bytes_compressed += c as u64; }
+}
+pub fn prof_summary() -> String {
+    let g = PROF_STATS.lock().unwrap();
+    let mut v: Vec<(String, AdapterStat)> = g.iter().map(|(k, s)| (k.clone(), s.clone())).collect();
+    v.sort_by_key(|e| e.0.clone());
+    let mut out = String::new();
+    for (name, s) in v.into_iter() {
+        out.push_str(&format!("{}: runs={}, hits={}, misses={}, bytes={}, compressed={}\n", name, s.runs, s.cache_hits, s.cache_misses, s.bytes_uncompressed, s.bytes_compressed));
+    }
+    if let Some((gz,bz,xz,z)) = crate::adapters::decompress::tuned_caps() {
+        out.push_str(&format!("decompressor caps: gzip={}, bzip2={}, xz={}, zstd={}\n", gz, bz, xz, z));
+    }
+    out
+}
+
 async fn choose_adapter(
+    engine: &AdapterEngine,
     config: &RgaConfig,
     filepath_hint: &Path,
     archive_recursion_depth: i32,
     inp: &mut (impl AsyncBufRead + Unpin),
 ) -> Result<Option<(Arc<dyn FileAdapter>, FileMatcher, ActiveAdapters)>> {
-    let active_adapters = get_adapters_filtered(config.custom_adapters.clone(), &config.adapters)?;
-    let adapters = adapter_matcher(&active_adapters, config.accurate)?;
     let filename = filepath_hint
         .file_name()
         .ok_or_else(|| format_err!("Empty filename"))?;
     debug!("Archive recursion depth: {}", archive_recursion_depth);
 
+    let first = (engine.matcher)(FileMeta {
+        mimetype: None,
+        lossy_filename: filename.to_string_lossy().to_string(),
+    });
+    if first.is_some() {
+        return Ok(first.map(|e| (e.0, e.1, engine.active_adapters.clone())));
+    }
     let mimetype = if config.accurate {
-        let buf = inp.fill_buf().await?; // fill but do not consume!
-        if buf.starts_with(b"From \x0d") || buf.starts_with(b"From -") {
+        let buf = inp.fill_buf().await?;
+        let probe = &buf[..buf.len().min(8192)];
+        if probe.starts_with(b"From \x0d") || probe.starts_with(b"From -") {
             Some("application/mbox")
         } else {
-            let mimetype = tree_magic::from_u8(buf);
+            let mimetype = tree_magic::from_u8(probe);
             debug!("mimetype: {:?}", mimetype);
             Some(mimetype)
         }
     } else {
         None
     };
-    let adapter = adapters(FileMeta {
+    let second = (engine.matcher)(FileMeta {
         mimetype,
         lossy_filename: filename.to_string_lossy().to_string(),
     });
-    Ok(adapter.map(|e| (e.0, e.1, active_adapters)))
+    Ok(second.map(|e| (e.0, e.1, engine.active_adapters.clone())))
 }
 
 enum Ret {
     Recurse(AdaptInfo, Arc<dyn FileAdapter>, FileMatcher, ActiveAdapters),
     Passthrough(AdaptInfo),
 }
-async fn buf_choose_adapter(ai: AdaptInfo) -> Result<Ret> {
+async fn buf_choose_adapter(engine: &AdapterEngine, ai: AdaptInfo) -> Result<Ret> {
     let mut inp = BufReader::with_capacity(1 << 16, ai.inp);
     let adapter = choose_adapter(
+        engine,
         &ai.config,
         &ai.filepath_hint,
         ai.archive_recursion_depth,
@@ -82,7 +139,7 @@ async fn buf_choose_adapter(ai: AdaptInfo) -> Result<Ret> {
             // otherwise it should have been filtered out by rg pre-glob since rg can handle those better than us
             let allow_cat = !ai.is_real_file || ai.config.accurate;
             if allow_cat {
-                if ai.postprocess {
+                if ai.postprocess && !ai.config.no_prefix_filenames && !ai.config.no_prefix_for_adapters.iter().any(|s| s == "default" || s == "*") {
                     (
                         Arc::new(PostprocPrefix {}) as Arc<dyn FileAdapter>,
                         FileMatcher::Fast(FastFileMatcher::FileExtension("default".to_string())),
@@ -112,22 +169,37 @@ async fn buf_choose_adapter(ai: AdaptInfo) -> Result<Ret> {
  */
 pub async fn rga_preproc(ai: AdaptInfo) -> Result<ReadBox> {
     debug!("path (hint) to preprocess: {:?}", ai.filepath_hint);
+    let engine = make_engine(&ai.config)?;
+    if let Some(maxb) = ai.config.max_file_bytes
+        && ai.is_real_file
+        && let std::result::Result::Ok(md) = std::fs::metadata(&ai.filepath_hint)
+        && md.len() as usize > maxb {
+        let allow_cat = !ai.config.no_prefix_filenames && ai.postprocess && !ai.config.no_prefix_for_adapters.iter().any(|s| s == "default" || s == "*");
+        if allow_cat {
+            let ai2 = AdaptInfo { inp: ai.inp, filepath_hint: ai.filepath_hint, is_real_file: ai.is_real_file, archive_recursion_depth: ai.archive_recursion_depth, line_prefix: ai.line_prefix, config: ai.config.clone(), postprocess: false };
+            let path_hint_copy = ai2.filepath_hint.clone();
+            return adapt_caching(&engine, ai2, Arc::new(PostprocPrefix {}), FileMatcher::Fast(FastFileMatcher::FileExtension("default".to_string())), vec![]).await.with_context(|| format!("run_adapter({})", &path_hint_copy.to_string_lossy()));
+        } else {
+            return Ok(ai.inp);
+        }
+    }
 
     // todo: figure out when using a bufreader is a good idea and when it is not
     // seems to be good for File::open() reads, but not sure about within archives (tar, zip)
-    let (ai, adapter, detection_reason, active_adapters) = match buf_choose_adapter(ai).await? {
+    let (ai, adapter, detection_reason, active_adapters) = match buf_choose_adapter(&engine, ai).await? {
         Ret::Recurse(ai, a, b, c) => (ai, a, b, c),
         Ret::Passthrough(ai) => {
             return Ok(ai.inp);
         }
     };
     let path_hint_copy = ai.filepath_hint.clone();
-    adapt_caching(ai, adapter, detection_reason, active_adapters)
+    adapt_caching(&engine, ai, adapter, detection_reason, active_adapters)
         .await
         .with_context(|| format!("run_adapter({})", &path_hint_copy.to_string_lossy()))
 }
 
 async fn adapt_caching(
+    engine: &AdapterEngine,
     ai: AdaptInfo,
     adapter: Arc<dyn FileAdapter>,
     detection_reason: FileMatcher,
@@ -138,7 +210,7 @@ async fn adapt_caching(
         "Chose adapter '{}' because of matcher {:?}",
         &meta.name, &detection_reason
     );
-    eprintln!(
+    debug!(
         "{} adapter: {}",
         ai.filepath_hint.to_string_lossy(),
         &meta.name
@@ -151,8 +223,12 @@ async fn adapt_caching(
     } else {
         None
     };
-
-    let mut cache = cache.context("No cache?")?;
+    if cache.is_none() {
+        let inp = loop_adapt(engine.clone(), adapter.as_ref(), detection_reason, ai).await?;
+        let inp = concat_read_streams(inp);
+        return Ok(Box::pin(inp));
+    }
+    let mut cache = cache.unwrap();
     let cache_key = CacheKey::new(
         ai.postprocess,
         &ai.filepath_hint,
@@ -162,28 +238,36 @@ async fn adapt_caching(
     // let dbg_ctx = format!("adapter {}", &adapter.metadata().name);
     let cached = cache.get(&cache_key).await.context("cache.get")?;
     match cached {
-        Some(cached) => Ok(Box::pin(ZstdDecoder::new(Cursor::new(cached)))),
+        Some(cached) => {
+            if ai.config.profile { prof_hit(&adapter.metadata().name); }
+            Ok(Box::pin(ZstdDecoder::new(Cursor::new(cached))))
+        },
         None => {
             debug!("cache MISS, running adapter with caching...");
-            let inp = loop_adapt(adapter.as_ref(), detection_reason, ai).await?;
+            let profile_enabled = ai.config.profile;
+            let adapter_name = adapter.metadata().name.clone();
+            let small_uncompressed = if ai.config.cache.disable_small_uncompressed { 0 } else { ai.config.cache.small_uncompressed_bytes.0 };
+            let inp = loop_adapt(engine.clone(), adapter.as_ref(), detection_reason, ai).await?;
             let inp = concat_read_streams(inp);
             let inp = async_read_and_write_to_cache(
                 inp,
                 cache_max_blob_len.0,
                 cache_compression_level.0,
+                small_uncompressed,
                 Box::new(move |(uncompressed_size, compressed)| {
                     Box::pin(async move {
                         debug!(
                             "uncompressed output: {}",
                             print_bytes(uncompressed_size as f64)
                         );
-                        if let Some(cached) = compressed {
+                        if let Some(ref cached) = compressed {
                             debug!("compressed output: {}", print_bytes(cached.len() as f64));
                             cache
-                                .set(&cache_key, cached)
+                                .set(&cache_key, cached.to_vec())
                                 .await
                                 .context("writing to cache")?
                         }
+                        if profile_enabled { prof_miss(&adapter_name, uncompressed_size, compressed.as_ref().map(|c| c.len())); }
                         Ok(())
                     })
                 }),
@@ -206,13 +290,15 @@ async fn read_discard(mut x: ReadBox) -> Result<()> {
 }
 
 pub fn loop_adapt(
+    engine: AdapterEngine,
     adapter: &dyn FileAdapter,
     detection_reason: FileMatcher,
     ai: AdaptInfo,
 ) -> Pin<Box<dyn Future<Output = anyhow::Result<AdaptedFilesIterBox>> + Send + '_>> {
-    Box::pin(async move { loop_adapt_inner(adapter, detection_reason, ai).await })
+    Box::pin(async move { loop_adapt_inner(engine, adapter, detection_reason, ai).await })
 }
 pub async fn loop_adapt_inner(
+    engine: AdapterEngine,
     adapter: &dyn FileAdapter,
     detection_reason: FileMatcher,
     ai: AdaptInfo,
@@ -234,7 +320,7 @@ pub async fn loop_adapt_inner(
     let s = stream! {
         for await file in inp {
             trace!("next file");
-            match buf_choose_adapter(file?).await? {
+            match buf_choose_adapter(&engine, file?).await? {
                 Ret::Recurse(ai, adapter, detection_reason, _active_adapters) => {
                     if ai.archive_recursion_depth >= ai.config.max_archive_recursion.0 {
                         // some adapters (esp. zip) assume that the entry is read fully and might hang otherwise
@@ -250,12 +336,13 @@ pub async fn loop_adapt_inner(
                         "Chose adapter '{}' because of matcher {:?}",
                         &adapter.metadata().name, &detection_reason
                     );
-                    eprintln!(
+                    debug!(
                         "{} adapter: {}",
                         ai.filepath_hint.to_string_lossy(),
                         &adapter.metadata().name
                     );
-                    for await ifile in loop_adapt(adapter.as_ref(), detection_reason, ai).await? {
+                    let engine_c = engine.clone();
+                    for await ifile in loop_adapt(engine_c, adapter.as_ref(), detection_reason, ai).await? {
                         yield ifile;
                     }
                 }


### PR DESCRIPTION
Refactors preproc engine and cache handling; updates caching configuration; cleans adapter modules for maintainability. Base: e8cd555.

Testing:
- cargo build --workspace
- cargo test --workspace
- cargo run --bin rga-preproc -- --help

Merge order: #313  #314  #315  #316
Cross-links: #314, #315, #316

Merge preference: Rebase and merge to preserve atomic commits.