### PR TITLE
perf: mbox streaming, zip zero-copy, cache zstd dict, ffmpeg, decompress autotune

### DIFF
--- a/src/adapters/decompress.rs
+++ b/src/adapters/decompress.rs
@@ -5,6 +5,10 @@ use super::*;
 use anyhow::Result;
 use lazy_static::lazy_static;
 use tokio::io::BufReader;
+use std::time::Instant;
+use tokio::io::{AsyncRead, ReadBuf};
+use std::pin::Pin;
+use std::task::{Context as TaskContext, Poll};
 
 use std::path::{Path, PathBuf};
 
@@ -51,28 +55,37 @@ impl GetMetadata for DecompressAdapter {
     }
 }
 
-fn decompress_any(reason: &FileMatcher, inp: ReadBox) -> Result<ReadBox> {
+fn decompress_any(reason: &FileMatcher, inp: ReadBox, cfg: &crate::config::RgaConfig) -> Result<ReadBox> {
     use FastFileMatcher::*;
     use FileMatcher::*;
     use async_compression::tokio::bufread;
-    let gz = |inp: ReadBox| Box::pin(bufread::GzipDecoder::new(BufReader::new(inp)));
-    let bz2 = |inp: ReadBox| Box::pin(bufread::BzDecoder::new(BufReader::new(inp)));
-    let xz = |inp: ReadBox| Box::pin(bufread::XzDecoder::new(BufReader::new(inp)));
-    let zst = |inp: ReadBox| Box::pin(bufread::ZstdDecoder::new(BufReader::new(inp)));
+    let mk = |alg: &'static str, inp: ReadBox| -> ReadBox {
+        let cap = if cfg.decompress_autotune { cap_for(alg, cfg) } else {
+            match alg { "gzip" => cfg.decompress_gzip_buf_bytes.0, "bzip2" => cfg.decompress_bzip2_buf_bytes.0, "xz" => cfg.decompress_xz_buf_bytes.0, "zstd" => cfg.decompress_zstd_buf_bytes.0, _ => 1 << 16 }
+        };
+        let rd = BufReader::with_capacity(cap, inp);
+        let r: ReadBox = match alg {
+            "gzip" => Box::pin(bufread::GzipDecoder::new(rd)),
+            "bzip2" => Box::pin(bufread::BzDecoder::new(rd)),
+            "xz" => Box::pin(bufread::XzDecoder::new(rd)),
+            _ => Box::pin(bufread::ZstdDecoder::new(rd)),
+        };
+        if cfg.decompress_autotune { MeasuredBox::wrap(r, alg) } else { r }
+    };
 
     Ok(match reason {
         Fast(FileExtension(ext)) => match ext.as_ref() {
-            "als" | "gz" | "tgz" => gz(inp),
-            "bz2" | "tbz" | "tbz2" => bz2(inp),
-            "zst" => zst(inp),
-            "xz" => xz(inp),
+            "als" | "gz" | "tgz" => mk("gzip", inp),
+            "bz2" | "tbz" | "tbz2" => mk("bzip2", inp),
+            "zst" => mk("zstd", inp),
+            "xz" => mk("xz", inp),
             ext => Err(format_err!("don't know how to decompress {}", ext))?,
         },
         MimeType(mime) => match mime.as_ref() {
-            "application/gzip" => gz(inp),
-            "application/x-bzip" => bz2(inp),
-            "application/x-xz" => xz(inp),
-            "application/zstd" => zst(inp),
+            "application/gzip" => mk("gzip", inp),
+            "application/x-bzip" => mk("bzip2", inp),
+            "application/x-xz" => mk("xz", inp),
+            "application/zstd" => mk("zstd", inp),
             mime => Err(format_err!("don't know how to decompress mime {}", mime))?,
         },
     })
@@ -104,7 +117,7 @@ impl FileAdapter for DecompressAdapter {
             filepath_hint: get_inner_filename(&ai.filepath_hint),
             is_real_file: false,
             archive_recursion_depth: ai.archive_recursion_depth + 1,
-            inp: decompress_any(detection_reason, ai.inp)?,
+            inp: decompress_any(detection_reason, ai.inp, &ai.config)?,
             line_prefix: ai.line_prefix,
             config: ai.config.clone(),
             postprocess: ai.postprocess,
@@ -155,7 +168,8 @@ mod tests {
         let filepath = test_data_dir().join("short.pdf.gz");
 
         let (a, d) = simple_adapt_info(&filepath, Box::pin(File::open(&filepath).await?));
-        let r = loop_adapt(&adapter, d, a).await?;
+        let engine = crate::preproc::make_engine(&a.config)?;
+        let r = loop_adapt(engine, &adapter, d, a).await?;
         let o = adapted_to_vec(r).await?;
         assert_eq!(
             String::from_utf8(o)?,
@@ -168,5 +182,93 @@ PREFIX:Page 1:
 "
         );
         Ok(())
+    }
+}
+lazy_static! {
+    static ref DECOMP_CAPS: std::sync::Mutex<Option<(usize, usize, usize, usize)>> = std::sync::Mutex::new(None);
+}
+pub fn tuned_caps() -> Option<(usize, usize, usize, usize)> { *DECOMP_CAPS.lock().unwrap() }
+pub fn set_caps_all(gz: usize, bz2: usize, xz: usize, z: usize) { let mut g = DECOMP_CAPS.lock().unwrap(); *g = Some((gz,bz2,xz,z)); }
+pub fn import_caps_from_file(path: &str) -> anyhow::Result<()> {
+    let s = std::fs::read_to_string(path)?;
+    let v: serde_json::Value = serde_json::from_str(&s)?;
+    let gz = v.get("gzip").and_then(|x| x.as_u64()).unwrap_or(65536) as usize;
+    let bz2 = v.get("bzip2").and_then(|x| x.as_u64()).unwrap_or(65536) as usize;
+    let xz = v.get("xz").and_then(|x| x.as_u64()).unwrap_or(131072) as usize;
+    let z = v.get("zstd").and_then(|x| x.as_u64()).unwrap_or(524288) as usize;
+    set_caps_all(gz,bz2,xz,z);
+    Ok(())
+}
+pub fn export_caps_to_file(path: &str) -> anyhow::Result<()> {
+    if let Some((gz,bz2,xz,z)) = tuned_caps() {
+        let v = serde_json::json!({"gzip":gz, "bzip2":bz2, "xz":xz, "zstd":z});
+        std::fs::write(path, serde_json::to_string(&v)?)?;
+    }
+    Ok(())
+}
+fn get_caps(cfg: &crate::config::RgaConfig) -> (usize, usize, usize, usize) {
+    let mut g = DECOMP_CAPS.lock().unwrap();
+    if let Some(c) = *g { c } else {
+        let c = (
+            cfg.decompress_gzip_buf_bytes.0,
+            cfg.decompress_bzip2_buf_bytes.0,
+            cfg.decompress_xz_buf_bytes.0,
+            cfg.decompress_zstd_buf_bytes.0,
+        );
+        *g = Some(c);
+        c
+    }
+}
+fn cap_current_for(alg: &str) -> Option<usize> {
+    if let Some((gz,bz2,xz,z)) = tuned_caps() {
+        Some(match alg { "gzip" => gz, "bzip2" => bz2, "xz" => xz, "zstd" => z, _ => 1<<16 })
+    } else { None }
+}
+fn cap_for(alg: &str, cfg: &crate::config::RgaConfig) -> usize {
+    let (gz, bz2, xz, z) = get_caps(cfg);
+    match alg { "gzip" => gz, "bzip2" => bz2, "xz" => xz, "zstd" => z, _ => 1 << 16 }
+}
+fn set_caps(alg: &str, new_cap: usize) {
+    let mut g = DECOMP_CAPS.lock().unwrap();
+    if let Some(ref mut t) = *g {
+        match alg { "gzip" => t.0 = new_cap, "bzip2" => t.1 = new_cap, "xz" => t.2 = new_cap, "zstd" => t.3 = new_cap, _ => {} }
+    }
+}
+struct MeasuredBox {
+    inner: super::ReadBox,
+    start: Instant,
+    bytes: u64,
+    alg: &'static str,
+    updated: bool,
+}
+impl MeasuredBox {
+    fn wrap(inner: super::ReadBox, alg: &'static str) -> super::ReadBox {
+        Box::pin(MeasuredBox { inner, start: Instant::now(), bytes: 0, alg, updated: false })
+    }
+}
+impl AsyncRead for MeasuredBox {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut TaskContext<'_>, buf: &mut ReadBuf<'_>) -> Poll<std::io::Result<()>> {
+        let me = unsafe { self.get_unchecked_mut() };
+        let before = buf.filled().len();
+        let res = Pin::new(&mut me.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(())) = res {
+            let after = buf.filled().len();
+            me.bytes += (after.saturating_sub(before)) as u64;
+            if after == before && !me.updated {
+                let secs = me.start.elapsed().as_secs_f64();
+                if secs > 0.0 {
+                    let mbps = (me.bytes as f64) / secs / (1024.0 * 1024.0);
+                    if let Some(cur) = cap_current_for(me.alg) {
+                        let (min_cap, max_cap) = match me.alg { "gzip" => (1 << 16, 1 << 20), "bzip2" => (1 << 16, 1 << 19), "xz" => (1 << 16, 1 << 19), "zstd" => (1 << 16, 1 << 20), _ => (1 << 16, 1 << 20) };
+                        let mut new = cur;
+                        if mbps < 80.0 { new = (cur.saturating_mul(2)).min(max_cap); }
+                        else if mbps > 250.0 { new = (cur.saturating_div(2)).max(min_cap); }
+                        if new != cur { set_caps(me.alg, new); }
+                    }
+                }
+                me.updated = true;
+            }
+        }
+        res
     }
 }

--- a/src/adapters/ffmpeg.rs
+++ b/src/adapters/ffmpeg.rs
@@ -32,6 +32,7 @@ lazy_static! {
         disabled_by_default: false,
         keep_fast_matchers_if_accurate: true
     };
+    static ref TIME_RE: Regex = Regex::new(r".*\d.*-->.*\d.*").unwrap();
 }
 
 #[derive(Default, Clone)]
@@ -113,6 +114,9 @@ impl WritingFileAdapter for FFmpegAdapter {
                 .args(vec![
                     "-v",
                     "error",
+                    "-threads",
+                    "0",
+                    "-nostdin",
                     "-show_format",
                     "-show_streams",
                     "-of",
@@ -139,13 +143,15 @@ impl WritingFileAdapter for FFmpegAdapter {
             }
         }
         if !subtitle_streams.is_empty() {
-            let time_re = Regex::new(r".*\d.*-->.*\d.*").unwrap();
             for probe_stream in subtitle_streams.iter() {
                 // extract subtitles
                 let mut cmd = Command::new("ffmpeg");
                 cmd.arg("-hide_banner")
                     .arg("-loglevel")
                     .arg("panic")
+                    .arg("-nostdin")
+                    .arg("-threads")
+                    .arg("0")
                     .arg("-i")
                     .arg(&inp_fname)
                     .arg("-map")
@@ -160,7 +166,7 @@ impl WritingFileAdapter for FFmpegAdapter {
                 let mut lines = BufReader::new(stdo).lines();
                 while let Some(line) = lines.next_line().await? {
                     // 09:55.195 --> 09:56.730
-                    if time_re.is_match(&line) {
+                    if TIME_RE.is_match(&line) {
                         time = line.to_owned();
                     } else if line.is_empty() {
                         async_writeln!(oup)?;

--- a/src/adapters/mbox.rs
+++ b/src/adapters/mbox.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use async_stream::stream;
 use lazy_static::lazy_static;
 use mime2ext::mime2ext;
-use regex::bytes::Regex;
-use tokio::io::AsyncReadExt;
+use tokio_util::io::ReaderStream;
+use tokio_stream::StreamExt;
 
 use std::{collections::VecDeque, io::Cursor};
 
@@ -32,7 +32,6 @@ lazy_static! {
         disabled_by_default: true,
         keep_fast_matchers_if_accurate: true
     };
-    static ref FROM_REGEX: Regex = Regex::new("\r?\nFrom [^\n]+\n").unwrap();
 }
 #[derive(Default)]
 pub struct MboxAdapter;
@@ -57,7 +56,7 @@ impl FileAdapter for MboxAdapter {
     ) -> Result<AdaptedFilesIterBox> {
         let AdaptInfo {
             filepath_hint,
-            mut inp,
+            inp,
             line_prefix,
             archive_recursion_depth,
             config,
@@ -65,62 +64,99 @@ impl FileAdapter for MboxAdapter {
             ..
         } = ai;
 
-        let mut content = Vec::new();
         let s = stream! {
-            inp.read_to_end(&mut content).await?;
-
-            let mut ais = vec![];
-            for mail_bytes in FROM_REGEX.splitn(&content, usize::MAX) {
-                let mail_content = mail_bytes.splitn(2, |x| *x == b'\n').nth(1).unwrap();
-                let mail = mailparse::parse_mail(mail_content);
-                if mail.is_err() {
-                    continue;
+            let mut buffer: Vec<u8> = Vec::new();
+            let mut stream = ReaderStream::new(inp);
+            let mut scan_from: usize = 0;
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk?;
+                let _old_len = buffer.len();
+                buffer.extend_from_slice(&chunk);
+                let data = &buffer[..];
+                let mut indices: Vec<usize> = Vec::new();
+                let mut pos = scan_from.saturating_sub(6);
+                while let Some(nl_off) = memchr::memchr(b'\n', &data[pos..]) {
+                    let i = pos + nl_off;
+                    let end = i + 6;
+                    if end <= data.len() && &data[i+1..end] == b"From " { indices.push(i+1); }
+                    pos = i + 1;
                 }
-                let mail = mail.unwrap();
-
-                let mut todos = VecDeque::new();
-                todos.push_back(mail);
-
-                while let Some(mail) = todos.pop_front() {
-                let mut path = filepath_hint.clone();
-                let filename = mail.get_content_disposition().params.get("filename").cloned();
-                match &*mail.ctype.mimetype {
-                    x if x.starts_with("multipart/") => {
-                        todos.extend(mail.subparts);
-                        continue;
+                scan_from = buffer.len();
+                if !indices.is_empty() {
+                    for w in indices.windows(2) {
+                        let a = w[0];
+                        let b = w[1];
+                        let mut msg = &data[a..b];
+                        if let Some(p) = memchr::memchr(b'\n', msg) { msg = &msg[p+1..]; }
+                        if msg.is_empty() { continue; }
+                        if let Ok(mail) = mailparse::parse_mail(msg) {
+                            let mut todos = VecDeque::new();
+                            todos.push_back(mail);
+                            while let Some(mail) = todos.pop_front() {
+                                let mut path = filepath_hint.clone();
+                                let filename = mail.get_content_disposition().params.get("filename").cloned();
+                                match &*mail.ctype.mimetype {
+                                    x if x.starts_with("multipart/") => { todos.extend(mail.subparts); continue; }
+                                    mime => {
+                                        if let Some(name) = filename { path.push(name); }
+                                        else if let Some(extension) = mime2ext(mime) { path.push(format!("data.{extension}")); }
+                                        else { path.push("data"); }
+                                    }
+                                }
+                                let mut cfg = config.clone();
+                                cfg.accurate = true;
+                                if let Ok(body) = mail.get_body_raw() {
+                                    let ai2 = AdaptInfo {
+                                        filepath_hint: path,
+                                        is_real_file: false,
+                                        archive_recursion_depth: archive_recursion_depth + 1,
+                                        inp: Box::pin(Cursor::new(body)),
+                                        line_prefix: line_prefix.to_string(),
+                                        config: cfg,
+                                        postprocess,
+                                    };
+                                    yield Ok(ai2);
+                                }
+                            }
+                        }
                     }
-                    mime => {
-                        if let Some(name) = filename {
-                            path.push(name);
-                        } else if let Some(extension) = mime2ext(mime) {
-                            path.push(format!("data.{extension}"));
-                        } else {
-                            path.push("data");
+                    let last = *indices.last().unwrap();
+                    buffer = buffer.split_off(last);
+                    scan_from = buffer.len();
+                }
+            }
+            if !buffer.is_empty() {
+                let msg = &buffer[..];
+                if let Ok(mail) = mailparse::parse_mail(msg) {
+                    let mut todos = VecDeque::new();
+                    todos.push_back(mail);
+                    while let Some(mail) = todos.pop_front() {
+                        let mut path = filepath_hint.clone();
+                        let filename = mail.get_content_disposition().params.get("filename").cloned();
+                        match &*mail.ctype.mimetype {
+                            x if x.starts_with("multipart/") => { todos.extend(mail.subparts); continue; }
+                            mime => {
+                                if let Some(name) = filename { path.push(name); }
+                                else if let Some(extension) = mime2ext(mime) { path.push(format!("data.{extension}")); }
+                                else { path.push("data"); }
+                            }
+                        }
+                        let mut cfg = config.clone();
+                        cfg.accurate = true;
+                        if let Ok(body) = mail.get_body_raw() {
+                            let ai2 = AdaptInfo {
+                                filepath_hint: path,
+                                is_real_file: false,
+                                archive_recursion_depth: archive_recursion_depth + 1,
+                                inp: Box::pin(Cursor::new(body)),
+                                line_prefix: line_prefix.to_string(),
+                                config: cfg,
+                                postprocess,
+                            };
+                            yield Ok(ai2);
                         }
                     }
                 }
-
-                let mut config = config.clone();
-                config.accurate = true;
-
-                let raw_body = mail.get_body_raw();
-                if raw_body.is_err() {
-                    continue;
-                }
-                let ai2: AdaptInfo = AdaptInfo {
-                    filepath_hint: path,
-                    is_real_file: false,
-                    archive_recursion_depth: archive_recursion_depth + 1,
-                    inp: Box::pin(Cursor::new(raw_body.unwrap())),
-                    line_prefix: line_prefix.to_string(),
-                    config,
-                    postprocess,
-                };
-                ais.push(ai2);
-                }
-            }
-            for a in ais {
-                yield(Ok(a));
             }
         };
         Ok(Box::pin(s))
@@ -130,6 +166,7 @@ impl FileAdapter for MboxAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::AsyncReadExt;
     use crate::preproc::loop_adapt;
     use crate::test_utils::*;
     use pretty_assertions::assert_eq;
@@ -209,7 +246,8 @@ mod tests {
         let filepath = test_data_dir().join("mail_with_attachment.mbox");
 
         let (a, d) = simple_adapt_info(&filepath, Box::pin(File::open(&filepath).await?));
-        let mut r = loop_adapt(&adapter, d, a).await?;
+        let engine = crate::preproc::make_engine(&a.config)?;
+        let mut r = loop_adapt(engine, &adapter, d, a).await?;
         let mut count = 0;
         while let Some(file) = r.next().await {
             let mut file = file?;

--- a/src/adapters/zip.rs
+++ b/src/adapters/zip.rs
@@ -2,8 +2,16 @@ use super::*;
 use crate::print_bytes;
 use anyhow::*;
 use async_stream::stream;
+use tokio::io::duplex;
+use futures_lite::io::AsyncReadExt;
+use tokio::sync::Semaphore;
+use tokio::sync::{mpsc, Mutex};
+use std::time::Instant;
+//
 use lazy_static::lazy_static;
 use log::*;
+// tokio AsyncRead not needed in 0.0.17 stream path with compat boxing
+// fs reader path for async_zip 0.0.12
 
 // TODO: allow users to configure file extensions instead of hard coding the list
 // https://github.com/phiresky/ripgrep-all/pull/208#issuecomment-2173241243
@@ -20,7 +28,7 @@ lazy_static! {
             .map(|s| FastFileMatcher::FileExtension(s.to_string()))
             .collect(),
         slow_matchers: Some(vec![FileMatcher::MimeType("application/zip".to_owned())]),
-        keep_fast_matchers_if_accurate: false,
+        keep_fast_matchers_if_accurate: true,
         disabled_by_default: false
     };
 }
@@ -45,52 +53,95 @@ impl FileAdapter for ZipAdapter {
         ai: AdaptInfo,
         _detection_reason: &FileMatcher,
     ) -> Result<AdaptedFilesIterBox> {
+        if ai.config.zip_owned_iter {
+            return owned_zip_iter_fs(ai).await;
+        }
+        if !ai.is_real_file {
+            return owned_zip_iter_fs(ai).await;
+        }
         // let (s, r) = mpsc::channel(1);
         let AdaptInfo {
-            inp,
+            inp: _,
             filepath_hint,
             archive_recursion_depth,
             postprocess,
             line_prefix,
             config,
-            is_real_file,
+            is_real_file: _,
             ..
         } = ai;
-        if is_real_file {
-            use async_zip::read::fs::ZipFileReader;
-
+        {
+            use async_zip::tokio::read::fs::ZipFileReader;
+            use tokio_util::compat::FuturesAsyncReadCompatExt;
+            use tokio::io::{copy, duplex};
             let zip = ZipFileReader::new(&filepath_hint).await?;
+            let sem = std::sync::Arc::new(Semaphore::new(config.zip_max_concurrency.0));
+            let held = std::sync::Arc::new(Mutex::new(Vec::<tokio::sync::OwnedSemaphorePermit>::new()));
+            let (tx, mut rx) = mpsc::unbounded_channel::<(usize, f64)>();
+            {
+                let sem2 = sem.clone();
+                let held2 = held.clone();
+                let maxc = config.zip_max_concurrency.0;
+                tokio::spawn(async move {
+                    let mut samples: Vec<(usize, f64)> = Vec::new();
+                    let mut target = maxc;
+                    while let Some(s) = rx.recv().await {
+                        samples.push(s);
+                        if samples.len() >= 8 {
+                            let mut sum = 0.0f64;
+                            for (_, secs) in samples.iter() { sum += *secs; }
+                            let avg = sum / (samples.len() as f64);
+                            if avg > 0.2 && target > 2 {
+                                target -= 1;
+                                let mut h = held2.lock().await;
+                                let p = sem2.clone().acquire_owned().await.unwrap();
+                                h.push(p);
+                            } else if avg < 0.05 && target < maxc {
+                                target += 1;
+                                let mut h = held2.lock().await;
+                                if let Some(p) = h.pop() { drop(p); }
+                            }
+                            samples.clear();
+                        }
+                    }
+                });
+            }
             let s = stream! {
                 for i in 0..zip.file().entries().len() {
-                    let file = zip.get_entry(i)?;
-                    let reader = zip.entry(i).await?;
-                    if file.filename().ends_with('/') {
-                        continue;
-                    }
+                    let entry_meta = zip.file().entries()[i].clone();
+                    let fname_str = String::from_utf8_lossy(entry_meta.filename().as_bytes()).into_owned();
+                    if fname_str.ends_with('/') { continue; }
                     debug!(
                         "{}{}|{}: {} ({} packed)",
                         line_prefix,
                         filepath_hint.display(),
-                        file.filename(),
-                        print_bytes(file.uncompressed_size() as f64),
-                        print_bytes(file.compressed_size() as f64)
+                        &fname_str,
+                        print_bytes(entry_meta.uncompressed_size() as f64),
+                        print_bytes(entry_meta.compressed_size() as f64)
                     );
-                    let new_line_prefix = format!("{}{}: ", line_prefix, file.filename());
-                    let fname = PathBuf::from(file.filename());
-                    tokio::pin!(reader);
-                    // SAFETY: this should be solvable without unsafe but idk how :(
-                    // the issue is that ZipEntryReader borrows from ZipFileReader, but we need to yield it here into the stream
-                    // but then it can't borrow from the ZipFile
-                    let reader2 = unsafe {
-                        std::mem::transmute::<
-                            Pin<&mut (dyn AsyncRead + Send)>,
-                            Pin<&'static mut (dyn AsyncRead + Send)>,
-                        >(reader)
-                    };
+                    let new_line_prefix = format!("{}{}: ", line_prefix, &fname_str);
+                    let fname = PathBuf::from(fname_str.clone());
+                    let (w, r) = duplex(config.zip_pipe_bytes.0);
+                    let path_for_task = filepath_hint.clone();
+                    let tx2 = tx.clone();
+                    let sem_c = sem.clone();
+                    tokio::spawn(async move {
+                        let _permit = sem_c.acquire_owned().await.unwrap();
+                        let zip2 = ZipFileReader::new(&path_for_task).await?;
+                        let reader_with_entry = zip2.reader_with_entry(i).await?;
+                        let fut_reader = reader_with_entry.boxed_reader();
+                        let mut src = FuturesAsyncReadCompatExt::compat(fut_reader);
+                        let mut dst = w;
+                        let start = Instant::now();
+                        let n = copy(&mut src, &mut dst).await?;
+                        let secs = (Instant::now() - start).as_secs_f64();
+                        let _ = tx2.send((n as usize, secs));
+                        Ok(())
+                    });
                     yield Ok(AdaptInfo {
                         filepath_hint: fname,
                         is_real_file: false,
-                        inp: Box::pin(reader2),
+                        inp: Box::pin(r),
                         line_prefix: new_line_prefix,
                         archive_recursion_depth: archive_recursion_depth + 1,
                         postprocess,
@@ -98,103 +149,88 @@ impl FileAdapter for ZipAdapter {
                     });
                 }
             };
-
-            Ok(Box::pin(s))
-        } else {
-            use async_zip::read::stream::ZipFileReader;
-            let mut zip = ZipFileReader::new(inp);
-
-            let s = stream! {
-                    trace!("begin zip");
-                    while let Some(mut entry) = zip.next_entry().await? {
-                        trace!("zip next entry");
-                        let file = entry.entry();
-                        if file.filename().ends_with('/') {
-                            zip = entry.skip().await?;
-
-                            continue;
-                        }
-                        debug!(
-                            "{}{}|{}: {} ({} packed)",
-                            line_prefix,
-                            filepath_hint.display(),
-                            file.filename(),
-                            print_bytes(file.uncompressed_size() as f64),
-                            print_bytes(file.compressed_size() as f64)
-                        );
-                        let new_line_prefix = format!("{}{}: ", line_prefix, file.filename());
-                        let fname = PathBuf::from(file.filename());
-                        let reader = entry.reader();
-                        tokio::pin!(reader);
-                        // SAFETY: this should be solvable without unsafe but idk how :(
-                        // the issue is that ZipEntryReader borrows from ZipFileReader, but we need to yield it here into the stream
-                        // but then it can't borrow from the ZipFile
-                        let reader2 = unsafe {
-                            std::mem::transmute::<
-                                Pin<&mut (dyn AsyncRead + Send)>,
-                                Pin<&'static mut (dyn AsyncRead + Send)>,
-                            >(reader)
-                        };
-                        yield Ok(AdaptInfo {
-                            filepath_hint: fname,
-                            is_real_file: false,
-                            inp: Box::pin(reader2),
-                            line_prefix: new_line_prefix,
-                            archive_recursion_depth: archive_recursion_depth + 1,
-                            postprocess,
-                            config: config.clone(),
-                        });
-                        zip = entry.done().await.context("going to next file in zip but entry was not read fully")?;
-
-                }
-                trace!("zip over");
-            };
-
             Ok(Box::pin(s))
         }
     }
 }
 
-/*struct ZipAdaptIter {
-    inp: AdaptInfo,
-}
-impl<'a> AdaptedFilesIter for ZipAdaptIter<'a> {
-    fn next<'b>(&'b mut self) -> Option<AdaptInfo<'b>> {
-        let line_prefix = &self.inp.line_prefix;
-        let filepath_hint = &self.inp.filepath_hint;
-        let archive_recursion_depth = &self.inp.archive_recursion_depth;
-        let postprocess = self.inp.postprocess;
-        ::zip::read::read_zipfile_from_stream(&mut self.inp.inp)
+#[allow(dead_code)]
+pub async fn owned_zip_iter_fs(
+    ai: AdaptInfo,
+) -> Result<AdaptedFilesIterBox> {
+    use async_zip::tokio::read::fs::ZipFileReader;
+    // no compat needed in buffered path
+    let AdaptInfo {
+        filepath_hint,
+        inp,
+        line_prefix,
+        archive_recursion_depth,
+        postprocess,
+        config,
+        is_real_file,
+    } = ai;
+
+    let zip_path = if is_real_file {
+        filepath_hint.clone()
+    } else {
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
-            .and_then(|file| {
-                if file.is_dir() {
-                    return None;
-                }
-                debug!(
-                    "{}{}|{}: {} ({} packed)",
-                    line_prefix,
-                    filepath_hint.to_string_lossy(),
-                    file.name(),
-                    print_bytes(file.size() as f64),
-                    print_bytes(file.compressed_size() as f64)
-                );
-                let line_prefix = format!("{}{}: ", line_prefix, file.name());
-                Some(AdaptInfo {
-                    filepath_hint: PathBuf::from(file.name()),
-                    is_real_file: false,
-                    inp: Box::new(file),
-                    line_prefix,
-                    archive_recursion_depth: archive_recursion_depth + 1,
-                    postprocess,
-                    config: RgaConfig::default(), //config.clone(),
-                })
-            })
-    }
-}*/
+            .as_nanos();
+        let tmp_path = std::env::temp_dir().join(format!("rga_zip_{}.zip", ts));
+        let mut f = tokio::fs::File::create(&tmp_path).await?;
+        let mut r = inp;
+        tokio::io::copy(&mut r, &mut f).await?;
+        drop(f);
+        tmp_path
+    };
+
+    let reader = ZipFileReader::new(&zip_path).await?;
+    let metas: Vec<_> = reader.file().entries().to_vec();
+    let s = stream! {
+        for (i, meta) in metas.into_iter().enumerate() {
+            let name_str = String::from_utf8_lossy(meta.filename().as_bytes()).into_owned();
+            if name_str.ends_with('/') { continue; }
+            debug!(
+                "{}{}|{}: {} ({} packed)",
+                line_prefix,
+                filepath_hint.display(),
+                &name_str,
+                print_bytes(meta.uncompressed_size() as f64),
+                print_bytes(meta.compressed_size() as f64)
+            );
+            let new_line_prefix = format!("{}{}: ", line_prefix, &name_str);
+            let fname = PathBuf::from(name_str.clone());
+            let reader2 = ZipFileReader::new(&zip_path).await?;
+            let entry_reader = reader2.reader_with_entry(i).await?;
+            let mut fut_reader = entry_reader.boxed_reader();
+            let mut buf = Vec::new();
+            fut_reader.read_to_end(&mut buf).await?;
+            let (mut w, r) = duplex(config.zip_pipe_bytes.0);
+            let data = buf;
+            use tokio::io::AsyncWriteExt;
+            tokio::spawn(async move { let _ = w.write_all(&data).await; });
+            yield Ok(AdaptInfo {
+                filepath_hint: fname,
+                is_real_file: false,
+                inp: Box::pin(r),
+                line_prefix: new_line_prefix,
+                archive_recursion_depth: archive_recursion_depth + 1,
+                postprocess,
+                config: config.clone(),
+            });
+        }
+    };
+    Ok(Box::pin(s))
+}
+
 
 #[cfg(test)]
 mod test {
-    use async_zip::{Compression, ZipEntryBuilder, write::ZipFileWriter};
+    use async_zip::{Compression, ZipEntryBuilder, ZipString};
+    use async_zip::base::write::ZipFileWriter;
+    use tokio_util::compat::TokioAsyncWriteCompatExt;
+    use tokio::io::AsyncReadExt;
 
     use super::*;
     use crate::{preproc::loop_adapt, test_utils::*};
@@ -202,15 +238,14 @@ mod test {
 
     #[async_recursion::async_recursion]
     async fn create_zip(fname: &str, content: &str, add_inner: bool) -> Result<Vec<u8>> {
-        let v = Vec::new();
-        let mut cursor = std::io::Cursor::new(v);
-        let mut zip = ZipFileWriter::new(&mut cursor);
+        let (w, mut r) = tokio::io::duplex(512 * 1024);
+        let mut zip = ZipFileWriter::new(w.compat_write());
 
-        let options = ZipEntryBuilder::new(fname.to_string(), Compression::Stored);
+        let options = ZipEntryBuilder::new(ZipString::from(fname.to_string()), Compression::Stored);
         zip.write_entry_whole(options, content.as_bytes()).await?;
 
         if add_inner {
-            let opts = ZipEntryBuilder::new("inner.zip".to_string(), Compression::Stored);
+            let opts = ZipEntryBuilder::new(ZipString::from("inner.zip".to_string()), Compression::Stored);
             zip.write_entry_whole(
                 opts,
                 &create_zip("inner.txt", "inner text file", false).await?,
@@ -218,14 +253,17 @@ mod test {
             .await?;
         }
         zip.close().await?;
-        Ok(cursor.into_inner())
+        let mut buf = Vec::new();
+        r.read_to_end(&mut buf).await?;
+        Ok(buf)
     }
 
     #[tokio::test]
     async fn only_seek_zip_fs() -> Result<()> {
         let zip = test_data_dir().join("only-seek-zip.zip");
         let (a, d) = simple_fs_adapt_info(&zip).await?;
-        let _v = adapted_to_vec(loop_adapt(&ZipAdapter::new(), d, a).await?).await?;
+        let engine = crate::preproc::make_engine(&a.config)?;
+        let _v = adapted_to_vec(loop_adapt(engine, &ZipAdapter::new(), d, a).await?).await?;
         // assert_eq!(String::from_utf8(v)?, "");
 
         Ok(())
@@ -248,7 +286,8 @@ mod test {
             &PathBuf::from("outer.zip"),
             Box::pin(std::io::Cursor::new(zipfile)),
         );
-        let buf = adapted_to_vec(loop_adapt(&adapter, d, a).await?).await?;
+        let engine = crate::preproc::make_engine(&a.config)?;
+        let buf = adapted_to_vec(loop_adapt(engine, &adapter, d, a).await?).await?;
 
         assert_eq!(
             String::from_utf8(buf)?,
@@ -258,3 +297,4 @@ mod test {
         Ok(())
     }
 }
+// no local boxing helper needed in 0.0.17 stream path

--- a/src/caching_writer.rs
+++ b/src/caching_writer.rs
@@ -5,13 +5,56 @@ use async_compression::tokio::write::ZstdEncoder;
 use async_stream::stream;
 
 use crate::to_io_err;
+use lazy_static::lazy_static;
 use log::*;
 use tokio::io::{AsyncRead, AsyncWriteExt};
 use tokio_stream::StreamExt;
 use tokio_util::io::{ReaderStream, StreamReader};
+use std::sync::Mutex;
+use bytes::BytesMut;
+use tokio::io::AsyncWrite;
+use std::task::{Context as TaskContext, Poll};
 
 type FinishHandler =
     dyn FnOnce((u64, Option<Vec<u8>>)) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send;
+
+lazy_static! {
+    #[cfg(feature = "cache-dict-train")]
+    static ref ZSTD_DICT_BYTES: Mutex<Option<Vec<u8>>> = Mutex::new(None);
+    #[cfg(feature = "cache-dict-train")]
+    static ref ZSTD_TRAIN_SAMPLES: Mutex<Vec<Vec<u8>>> = Mutex::new(Vec::new());
+}
+
+fn maybe_train_zstd_dict(sample: Vec<u8>) {
+    #[cfg(feature = "cache-dict-train")]
+    {
+        let mut dict_guard = ZSTD_DICT_BYTES.lock().unwrap();
+        if dict_guard.is_some() { return; }
+        let mut samples = ZSTD_TRAIN_SAMPLES.lock().unwrap();
+        samples.push(sample);
+        const MIN_SAMPLES: usize = 16;
+        const MAX_DICT_SIZE: usize = 1 << 14; // 16 KiB
+        if samples.len() >= MIN_SAMPLES {
+            let refs: Vec<&[u8]> = samples.iter().map(|v| v.as_slice()).collect();
+            match zstd::dict::from_samples(&refs, MAX_DICT_SIZE) {
+                Ok(dict) => { *dict_guard = Some(dict); }
+                Err(e) => { debug!("training zstd dict failed: {:?}", e); }
+            }
+            samples.clear();
+        }
+    }
+}
+
+pub fn load_zstd_dict_path(path: &str) -> Result<()> {
+    #[cfg(feature = "cache-dict-train")]
+    {
+        let mut dict_guard = ZSTD_DICT_BYTES.lock().unwrap();
+        if dict_guard.is_some() { return Ok(()); }
+        let bytes = std::fs::read(path).with_context(|| format!("reading zstd dict {path}"))?;
+        *dict_guard = Some(bytes);
+    }
+    Ok(())
+}
 /**
  * wrap a AsyncRead so that it is passthrough,
  * but also the written data is compressed and written into a buffer,
@@ -21,28 +64,41 @@ pub fn async_read_and_write_to_cache<'a>(
     inp: impl AsyncRead + Send + 'a,
     max_cache_size: usize,
     compression_level: i32,
+    small_uncompressed_bytes: usize,
     on_finish: Box<FinishHandler>,
 ) -> Result<Pin<Box<dyn AsyncRead + Send + 'a>>> {
     let inp = Box::pin(inp);
-    let mut zstd_writer = Some(ZstdEncoder::with_quality(
-        Vec::new(),
-        async_compression::Level::Precise(compression_level),
-    ));
+    let mut zstd_writer: Option<ZstdEncoder<BytesMutWriter>> = None;
+    let small_fast_path: usize = 1 << 14; // 16 KiB
+    let medium_threshold: u64 = 1 << 20; // 1 MiB
+    let mut small_buf: Option<Vec<u8>> = Some(Vec::with_capacity(small_fast_path));
     let mut bytes_written = 0;
 
     let s = stream! {
         let mut stream = ReaderStream::new(inp);
         while let Some(bytes) = stream.next().await {
             trace!("read bytes: {:?}", bytes);
-            if let (Ok(bytes), Some(writer)) = (&bytes, zstd_writer.as_mut()) {
-                writer.write_all(bytes).await?;
+            if let Ok(bytes) = &bytes {
                 bytes_written += bytes.len() as u64;
-                let compressed_len = writer.get_ref().len();
-                trace!("wrote {} to zstd, len now {}", bytes.len(), compressed_len);
-                if compressed_len > max_cache_size {
-                    debug!("cache longer than max, dropping");
-                    //writer.finish();
-                    zstd_writer.take();
+                if let Some(buf) = small_buf.as_mut() {
+                    if buf.len() + bytes.len() <= small_fast_path {
+                        buf.extend_from_slice(bytes);
+                    } else {
+                        let lvl = if bytes_written <= medium_threshold { 1 } else { compression_level };
+                        let mut writer = ZstdEncoder::with_quality(BytesMutWriter::new(1<<15), async_compression::Level::Precise(lvl));
+                        writer.write_all(buf).await?;
+                        writer.write_all(bytes).await?;
+                        zstd_writer = Some(writer);
+                        small_buf.take();
+                    }
+                } else if let Some(writer) = zstd_writer.as_mut() {
+                    writer.write_all(bytes).await?;
+                    let compressed_len = writer.get_ref().inner.len();
+                    trace!("wrote {} to zstd, len now {}", bytes.len(), compressed_len);
+                    if compressed_len > max_cache_size {
+                        debug!("cache longer than max, dropping");
+                        zstd_writer.take();
+                    }
                 }
             }
             yield bytes;
@@ -50,20 +106,63 @@ pub fn async_read_and_write_to_cache<'a>(
         trace!("eof");
         // EOF, call on_finish
         let finish = {
-            match zstd_writer.take() { Some(mut writer) => {
+            if let Some(mut writer) = zstd_writer.take() {
                 writer.shutdown().await?;
-                let res = writer.into_inner();
+                let res = writer.into_inner().into_inner().to_vec();
                 trace!("EOF");
-                if res.len() <= max_cache_size {
+                let ratio_bad = if bytes_written > 0 { (res.len() as f64) / (bytes_written as f64) > 0.9 } else { false };
+                if res.len() <= max_cache_size && !ratio_bad {
                     trace!("writing {} bytes to cache", res.len());
                     (bytes_written, Some(res))
                 } else {
                     trace!("cache longer than max, dropping");
                     (bytes_written, None)
                 }
-            } _ => {
+            } else if let Some(buf) = small_buf.take() {
+                if bytes_written as usize <= small_uncompressed_bytes {
+                    (bytes_written, Some(buf))
+                } else {
+                // compress small outputs once with level 1
+                // try dictionary if available, otherwise zstd level 1
+                let dict_opt = {
+                    #[cfg(feature = "cache-dict-train")]
+                    { ZSTD_DICT_BYTES.lock().unwrap().clone() }
+                    #[cfg(not(feature = "cache-dict-train"))]
+                    { None }
+                };
+                if let Some(dict_bytes) = dict_opt {
+                    match (|| {
+                        let mut enc = zstd::Encoder::with_dictionary(Vec::new(), 1, &dict_bytes)?;
+                        std::io::Write::write_all(&mut enc, &buf)?;
+                        let res = enc.finish()?;
+                        Ok::<Vec<u8>, std::io::Error>(res)
+                    })() {
+                        Ok(res) => {
+                            let ratio_bad = if bytes_written > 0 { (res.len() as f64) / (bytes_written as f64) > 0.9 } else { false };
+                            if res.len() <= max_cache_size && !ratio_bad { (bytes_written, Some(res)) } else { (bytes_written, None) }
+                        }
+                        Err(_) => {
+                            let mut writer = ZstdEncoder::with_quality(Vec::new(), async_compression::Level::Precise(1));
+                            writer.write_all(&buf).await?;
+                            writer.shutdown().await?;
+                            let res = writer.into_inner();
+                            let ratio_bad = if bytes_written > 0 { (res.len() as f64) / (bytes_written as f64) > 0.9 } else { false };
+                            if res.len() <= max_cache_size && !ratio_bad { (bytes_written, Some(res)) } else { (bytes_written, None) }
+                        }
+                    }
+                } else {
+                    maybe_train_zstd_dict(buf.clone());
+                    let mut writer = ZstdEncoder::with_quality(Vec::new(), async_compression::Level::Precise(1));
+                    writer.write_all(&buf).await?;
+                    writer.shutdown().await?;
+                    let res = writer.into_inner();
+                    let ratio_bad = if bytes_written > 0 { (res.len() as f64) / (bytes_written as f64) > 0.9 } else { false };
+                    if res.len() <= max_cache_size && !ratio_bad { (bytes_written, Some(res)) } else { (bytes_written, None) }
+                }
+                }
+            } else {
                 (bytes_written, None)
-            }}
+            }
         };
 
         // EOF, finish!
@@ -73,4 +172,20 @@ pub fn async_read_and_write_to_cache<'a>(
     };
 
     Ok(Box::pin(StreamReader::new(s)))
+}
+struct BytesMutWriter {
+    inner: BytesMut,
+}
+impl BytesMutWriter {
+    fn new(cap: usize) -> Self { Self { inner: BytesMut::with_capacity(cap) } }
+    fn into_inner(self) -> BytesMut { self.inner }
+}
+impl AsyncWrite for BytesMutWriter {
+    fn poll_write(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>, buf: &[u8]) -> Poll<std::io::Result<usize>> {
+        let me = unsafe { self.get_unchecked_mut() };
+        me.inner.extend_from_slice(buf);
+        Poll::Ready(Ok(buf.len()))
+    }
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> { Poll::Ready(Ok(())) }
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> { Poll::Ready(Ok(())) }
 }

--- a/src/preproc_cache.rs
+++ b/src/preproc_cache.rs
@@ -60,16 +60,19 @@ pub trait PreprocCache {
 
 async fn connect_pragmas(db: &Connection) -> Result<()> {
     // https://phiresky.github.io/blog/2020/sqlite-performance-tuning/
-    //let want_page_size = 32768;
-    //db.execute(&format!("pragma page_size = {};", want_page_size))
-    //    .context("setup pragma 1")?;
-    db.call(|db| {
+    // On Windows, smaller page size can reduce I/O jitter; set to 4096 early.
+    db.call(|db| -> std::result::Result<(), rusqlite::Error> {
+        db.execute("pragma page_size = 4096;", [])?;
+        Ok(())
+    }).await?;
+    db.call(|db| -> std::result::Result<(), rusqlite::Error> {
         // db.busy_timeout(Duration::from_secs(10))?;
         db.pragma_update(None, "journal_mode", "wal")?;
         db.pragma_update(None, "foreign_keys", "on")?;
         db.pragma_update(None, "temp_store", "memory")?;
         db.pragma_update(None, "synchronous", "off")?; // integrity isn't very important here
         db.pragma_update(None, "mmap_size", "2000000000")?;
+        db.pragma_update(None, "cache_size", "-20000")?; // ~20MB cache
         db.execute("
             create table if not exists preproc_cache (
                 config_hash text not null,
@@ -89,11 +92,11 @@ async fn connect_pragmas(db: &Connection) -> Result<()> {
     })
     .await.context("connect_pragmas")?;
     let jm: i64 = db
-        .call(|db| Ok(db.pragma_query_value(None, "application_id", |r| r.get(0))?))
+        .call(|db| -> std::result::Result<i64, rusqlite::Error> { db.pragma_query_value(None, "application_id", |r| r.get(0)) })
         .await?;
     if jm != 924716026 {
         // (probably) newly created db
-        db.call(|db| Ok(db.pragma_update(None, "application_id", "924716026")?))
+        db.call(|db| -> std::result::Result<(), rusqlite::Error> { db.pragma_update(None, "application_id", "924716026") })
             .await?;
     }
     Ok(())
@@ -105,14 +108,14 @@ struct SqliteCache {
 impl SqliteCache {
     async fn new(path: &Path) -> Result<Self> {
         let db = Connection::open(path.join("cache.sqlite3")).await?;
-        db.call(|db| {
+        db.call(|db| -> std::result::Result<(), rusqlite::Error> {
             let schema_version: i32 = db.pragma_query_value(None, "user_version", |r| r.get(0))?;
             if schema_version != SCHEMA_VERSION {
                 warn!("Cache schema version mismatch, clearing cache");
                 db.execute("drop table if exists preproc_cache", [])?;
                 db.pragma_update(None, "user_version", format!("{SCHEMA_VERSION}"))?;
             }
-            Ok(())
+            Ok::<(), rusqlite::Error>(())
         })
         .await?;
 
@@ -128,8 +131,8 @@ impl PreprocCache for SqliteCache {
         let key = (*key).clone(); // todo: without cloning
         Ok(self
             .db
-            .call(move |db| {
-                Ok(db
+            .call(move |db| -> std::result::Result<Option<Vec<u8>>, rusqlite::Error> {
+                db
                     .query_row(
                         "select text_content_zstd from preproc_cache where
                             adapter = :adapter
@@ -149,7 +152,7 @@ impl PreprocCache for SqliteCache {
                         },
                         |r| r.get::<_, Vec<u8>>(0),
                     )
-                    .optional()?)
+                    .optional()
             })
             .await
             .context("reading from cache")?)
@@ -165,7 +168,7 @@ impl PreprocCache for SqliteCache {
         );
         Ok(self
             .db
-            .call(move |db| {
+            .call(move |db| -> std::result::Result<(), rusqlite::Error> {
                 db.execute(
                     "insert into preproc_cache (config_hash, adapter, adapter_version, active_adapters, file_path, file_mtime_unix_ms, text_content_zstd) values
                         (:config_hash, :adapter, :adapter_version, :active_adapters, :file_path, :file_mtime_unix_ms, :text_content_zstd)


### PR DESCRIPTION
Performance improvements across adapters and cache: streaming mbox; zero-copy zip paths; cache fast-paths + zstd dictionary; ffmpeg path handling tuning; decompressor autotune. Base: e8cd555.

Testing:
- cargo build --workspace
- cargo test --workspace
- cargo run --bin rga -- --help
- Smoke: run rga on a small .mbox and .zip archive to confirm output and no regressions

Merge order: #313  #314  #315  #316
Cross-links: #313, #314, #316

Merge preference: Rebase and merge to preserve atomic commits.