### PR TITLE
Expose runtime dependencies in Nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -99,6 +99,7 @@
             };
             devShells.default = config.rust-project.crane-lib.devShell {
               inputsFrom = [
+                config.packages.default
                 config.pre-commit.devShell
                 config.treefmt.build.devShell
               ];


### PR DESCRIPTION
I realized after the fact that I accidentally dropped the runtime dependencies from the devshell as part of #306. That does not pose a problem when building via `nix`, but ideally the dependencies would be available for local builds when using `cargo` directly.