### PR TITLE
Fix --rga-no-cache flag causing "No cache?" error instead of disabling cache

### DIFF
--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -143,62 +143,54 @@ async fn adapt_caching(
         ai.filepath_hint.to_string_lossy(),
         &meta.name
     );
-    let cache = if ai.is_real_file && !ai.config.cache.disabled {
-        Some(open_cache_db(Path::new(&ai.config.cache.path.0)).await?)
+    // Note: adapt_caching is only called from rga_preproc for the top-level file.
+    // Recursive files inside archives go through loop_adapt directly and never hit this function,
+    // so in practice only --rga-no-cache triggers the None path here (is_real_file is always true).
+    let mut cache = if ai.is_real_file && !ai.config.cache.disabled {
+        open_cache_db(Path::new(&ai.config.cache.path.0)).await?
     } else {
-        None
+        debug!("cache disabled, running adapter without caching...");
+        let inp = loop_adapt(adapter.as_ref(), detection_reason, ai).await?;
+        return Ok(Box::pin(concat_read_streams(inp)));
     };
+    let cache_compression_level = ai.config.cache.compression_level;
+    let cache_max_blob_len = ai.config.cache.max_blob_len;
 
-    match cache {
-        Some(mut cache) => {
-            let cache_compression_level = ai.config.cache.compression_level;
-            let cache_max_blob_len = ai.config.cache.max_blob_len;
-            let cache_key = CacheKey::new(
-                ai.postprocess,
-                &ai.filepath_hint,
-                adapter.as_ref(),
-                &active_adapters,
-            )?;
-            let cached = cache.get(&cache_key).await.context("cache.get")?;
-            match cached {
-                Some(cached) => Ok(Box::pin(ZstdDecoder::new(Cursor::new(cached)))),
-                None => {
-                    debug!("cache MISS, running adapter with caching...");
-                    let inp = loop_adapt(adapter.as_ref(), detection_reason, ai).await?;
-                    let inp = concat_read_streams(inp);
-                    let inp = async_read_and_write_to_cache(
-                        inp,
-                        cache_max_blob_len.0,
-                        cache_compression_level.0,
-                        Box::new(move |(uncompressed_size, compressed)| {
-                            Box::pin(async move {
-                                debug!(
-                                    "uncompressed output: {}",
-                                    print_bytes(uncompressed_size as f64)
-                                );
-                                if let Some(cached) = compressed {
-                                    debug!(
-                                        "compressed output: {}",
-                                        print_bytes(cached.len() as f64)
-                                    );
-                                    cache
-                                        .set(&cache_key, cached)
-                                        .await
-                                        .context("writing to cache")?
-                                }
-                                Ok(())
-                            })
-                        }),
-                    )?;
-
-                    Ok(Box::pin(inp))
-                }
-            }
-        }
+    let cache_key = CacheKey::new(
+        ai.postprocess,
+        &ai.filepath_hint,
+        adapter.as_ref(),
+        &active_adapters,
+    )?;
+    let cached = cache.get(&cache_key).await.context("cache.get")?;
+    match cached {
+        Some(cached) => Ok(Box::pin(ZstdDecoder::new(Cursor::new(cached)))),
         None => {
-            debug!("cache disabled, running adapter without caching...");
+            debug!("cache MISS, running adapter with caching...");
             let inp = loop_adapt(adapter.as_ref(), detection_reason, ai).await?;
             let inp = concat_read_streams(inp);
+            let inp = async_read_and_write_to_cache(
+                inp,
+                cache_max_blob_len.0,
+                cache_compression_level.0,
+                Box::new(move |(uncompressed_size, compressed)| {
+                    Box::pin(async move {
+                        debug!(
+                            "uncompressed output: {}",
+                            print_bytes(uncompressed_size as f64)
+                        );
+                        if let Some(cached) = compressed {
+                            debug!("compressed output: {}", print_bytes(cached.len() as f64));
+                            cache
+                                .set(&cache_key, cached)
+                                .await
+                                .context("writing to cache")?
+                        }
+                        Ok(())
+                    })
+                }),
+            )?;
+
             Ok(Box::pin(inp))
         }
     }

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -143,52 +143,62 @@ async fn adapt_caching(
         ai.filepath_hint.to_string_lossy(),
         &meta.name
     );
-    let cache_compression_level = ai.config.cache.compression_level;
-    let cache_max_blob_len = ai.config.cache.max_blob_len;
-
     let cache = if ai.is_real_file && !ai.config.cache.disabled {
         Some(open_cache_db(Path::new(&ai.config.cache.path.0)).await?)
     } else {
         None
     };
 
-    let mut cache = cache.context("No cache?")?;
-    let cache_key = CacheKey::new(
-        ai.postprocess,
-        &ai.filepath_hint,
-        adapter.as_ref(),
-        &active_adapters,
-    )?;
-    // let dbg_ctx = format!("adapter {}", &adapter.metadata().name);
-    let cached = cache.get(&cache_key).await.context("cache.get")?;
-    match cached {
-        Some(cached) => Ok(Box::pin(ZstdDecoder::new(Cursor::new(cached)))),
+    match cache {
+        Some(mut cache) => {
+            let cache_compression_level = ai.config.cache.compression_level;
+            let cache_max_blob_len = ai.config.cache.max_blob_len;
+            let cache_key = CacheKey::new(
+                ai.postprocess,
+                &ai.filepath_hint,
+                adapter.as_ref(),
+                &active_adapters,
+            )?;
+            let cached = cache.get(&cache_key).await.context("cache.get")?;
+            match cached {
+                Some(cached) => Ok(Box::pin(ZstdDecoder::new(Cursor::new(cached)))),
+                None => {
+                    debug!("cache MISS, running adapter with caching...");
+                    let inp = loop_adapt(adapter.as_ref(), detection_reason, ai).await?;
+                    let inp = concat_read_streams(inp);
+                    let inp = async_read_and_write_to_cache(
+                        inp,
+                        cache_max_blob_len.0,
+                        cache_compression_level.0,
+                        Box::new(move |(uncompressed_size, compressed)| {
+                            Box::pin(async move {
+                                debug!(
+                                    "uncompressed output: {}",
+                                    print_bytes(uncompressed_size as f64)
+                                );
+                                if let Some(cached) = compressed {
+                                    debug!(
+                                        "compressed output: {}",
+                                        print_bytes(cached.len() as f64)
+                                    );
+                                    cache
+                                        .set(&cache_key, cached)
+                                        .await
+                                        .context("writing to cache")?
+                                }
+                                Ok(())
+                            })
+                        }),
+                    )?;
+
+                    Ok(Box::pin(inp))
+                }
+            }
+        }
         None => {
-            debug!("cache MISS, running adapter with caching...");
+            debug!("cache disabled, running adapter without caching...");
             let inp = loop_adapt(adapter.as_ref(), detection_reason, ai).await?;
             let inp = concat_read_streams(inp);
-            let inp = async_read_and_write_to_cache(
-                inp,
-                cache_max_blob_len.0,
-                cache_compression_level.0,
-                Box::new(move |(uncompressed_size, compressed)| {
-                    Box::pin(async move {
-                        debug!(
-                            "uncompressed output: {}",
-                            print_bytes(uncompressed_size as f64)
-                        );
-                        if let Some(cached) = compressed {
-                            debug!("compressed output: {}", print_bytes(cached.len() as f64));
-                            cache
-                                .set(&cache_key, cached)
-                                .await
-                                .context("writing to cache")?
-                        }
-                        Ok(())
-                    })
-                }),
-            )?;
-
             Ok(Box::pin(inp))
         }
     }


### PR DESCRIPTION
When cache is disabled (via --rga-no-cache) or the file is not a real file,
adapt_caching() set cache to None but then immediately called
cache.context("No cache?")? which unconditionally errored on the None value.

This is a regression introduced in cde0e20 ("partial move to async", Oct 2022).
The pre-async code in dfc10cb correctly used:
  if let Some(mut cache) = cache { /* cached path */ } else { /* no-cache path */ }
The async rewrite replaced this with:
  let mut cache = cache.context("No cache?")?;
dropping the else branch that ran the adapter without caching.

Fix by matching on the Option: when cache is Some, use the existing
read/write-through-cache path; when None, run the adapter directly without
any caching via loop_adapt() + concat_read_streams().

Fixes #337

https://claude.ai/code/session_014Yhbd16V3ekdKsdBtgt8Lq