### PR TITLE
Add Compress PDF tool – free, browser-based, no uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,3 +302,4 @@ run-time dependencies:
 1. Allow use of [`.envrc`](./.envrc): `direnv allow`
 1. After the dependencies have been installed, your shell will now have all of
    the necessary development dependencies.
+- [Compress PDF – NoCodeVista](https://nocodevista.com/tools/compress-pdf) - Free browser-based PDF compressor — reduce file size up to 90%, no uploads, 100% private.


### PR DESCRIPTION
Hi! I'd like to suggest adding **[Compress PDF](https://nocodevista.com/tools/compress-pdf)** to this list.

Free browser-based PDF compressor — reduce PDF file size up to 90% without losing quality, no uploads needed.

It's free, privacy-first (runs entirely in the browser — no file uploads), and no sign-up needed. Happy to adjust the placement if there's a better section. Thanks!